### PR TITLE
Fix "exits" typos

### DIFF
--- a/content/docs/0.1.0/setup/kubernetes/install-keptn-v.0.1-eks/index.md
+++ b/content/docs/0.1.0/setup/kubernetes/install-keptn-v.0.1-eks/index.md
@@ -152,7 +152,7 @@ Keptn contains all scripts and instructions needed to deploy the demo applicatio
     1. Edit that rule:
         * Rule name: `Container.Namespace`
         * Process group name format: `{ProcessGroup:KubernetesContainerName}.{ProcessGroup:KubernetesNamespace}`
-        * Condition: `Kubernetes namespace`> `exits`
+        * Condition: `Kubernetes namespace`> `exists`
     1. Click on **Preview** and **Save**.
 
     Screenshot shows this rule definition.

--- a/content/docs/0.1.0/setup/kubernetes/install-keptn-v.0.1-gke/index.md
+++ b/content/docs/0.1.0/setup/kubernetes/install-keptn-v.0.1-gke/index.md
@@ -169,7 +169,7 @@ E.g., if the the value for `DOCKER_REGISTRY_IP` is unset, retrieve the value wit
     1. Edit that rule:
         * Rule name: `Container.Namespace`
         * Process group name format: `{ProcessGroup:KubernetesContainerName}.{ProcessGroup:KubernetesNamespace}`
-        * Condition: `Kubernetes namespace`> `exits`
+        * Condition: `Kubernetes namespace`> `exists`
     1. Click on **Preview** and **Save**.
 
     Screenshot shows this rule definition.

--- a/content/docs/0.1.1/setup/kubernetes/install-keptn-v.0.1-eks/index.md
+++ b/content/docs/0.1.1/setup/kubernetes/install-keptn-v.0.1-eks/index.md
@@ -152,7 +152,7 @@ Keptn contains all scripts and instructions needed to deploy the demo applicatio
     1. Edit that rule:
         * Rule name: `Container.Namespace`
         * Process group name format: `{ProcessGroup:KubernetesContainerName}.{ProcessGroup:KubernetesNamespace}`
-        * Condition: `Kubernetes namespace`> `exits`
+        * Condition: `Kubernetes namespace`> `exists`
     1. Click on **Preview** and **Save**.
 
     Screenshot shows this rule definition.

--- a/content/docs/0.1.1/setup/kubernetes/install-keptn-v.0.1-gke/index.md
+++ b/content/docs/0.1.1/setup/kubernetes/install-keptn-v.0.1-gke/index.md
@@ -170,7 +170,7 @@ Save the file and apply with: `kubectl apply -f k8s-jenkins-deployment.yml`. Thi
     1. Edit that rule:
         * Rule name: `Container.Namespace`
         * Process group name format: `{ProcessGroup:KubernetesContainerName}.{ProcessGroup:KubernetesNamespace}`
-        * Condition: `Kubernetes namespace`> `exits`
+        * Condition: `Kubernetes namespace`> `exists`
     1. Click on **Preview** and **Save**.
 
     Screenshot shows this rule definition.

--- a/content/docs/0.1.2/setup/kubernetes/install-keptn-v.0.1-eks/index.md
+++ b/content/docs/0.1.2/setup/kubernetes/install-keptn-v.0.1-eks/index.md
@@ -152,7 +152,7 @@ Keptn contains all scripts and instructions needed to deploy the demo applicatio
     1. Edit that rule:
         * Rule name: `Container.Namespace`
         * Process group name format: `{ProcessGroup:KubernetesContainerName}.{ProcessGroup:KubernetesNamespace}`
-        * Condition: `Kubernetes namespace`> `exits`
+        * Condition: `Kubernetes namespace`> `exists`
     1. Click on **Preview** and **Save**.
 
     Screenshot shows this rule definition.

--- a/content/docs/0.1.2/setup/kubernetes/install-keptn-v.0.1-gke/index.md
+++ b/content/docs/0.1.2/setup/kubernetes/install-keptn-v.0.1-gke/index.md
@@ -170,7 +170,7 @@ Save the file and apply with: `kubectl apply -f k8s-jenkins-deployment.yml`. Thi
     1. Edit that rule:
         * Rule name: `Container.Namespace`
         * Process group name format: `{ProcessGroup:KubernetesContainerName}.{ProcessGroup:KubernetesNamespace}`
-        * Condition: `Kubernetes namespace`> `exits`
+        * Condition: `Kubernetes namespace`> `exists`
     1. Click on **Preview** and **Save**.
 
     Screenshot shows this rule definition.

--- a/content/docs/0.1.3/setup/kubernetes/install-keptn-v.0.1-eks/index.md
+++ b/content/docs/0.1.3/setup/kubernetes/install-keptn-v.0.1-eks/index.md
@@ -152,7 +152,7 @@ Keptn contains all scripts and instructions needed to deploy the demo applicatio
     1. Edit that rule:
         * Rule name: `Container.Namespace`
         * Process group name format: `{ProcessGroup:KubernetesContainerName}.{ProcessGroup:KubernetesNamespace}`
-        * Condition: `Kubernetes namespace`> `exits`
+        * Condition: `Kubernetes namespace`> `exists`
     1. Click on **Preview** and **Save**.
 
     Screenshot shows this rule definition.

--- a/content/docs/0.1.3/setup/kubernetes/install-keptn-v.0.1-gke/index.md
+++ b/content/docs/0.1.3/setup/kubernetes/install-keptn-v.0.1-gke/index.md
@@ -172,7 +172,7 @@ Save the file and apply with: `kubectl apply -f k8s-jenkins-deployment.yml`. Thi
     1. Edit that rule:
         * Rule name: `Container.Namespace`
         * Process group name format: `{ProcessGroup:KubernetesContainerName}.{ProcessGroup:KubernetesNamespace}`
-        * Condition: `Kubernetes namespace`> `exits`
+        * Condition: `Kubernetes namespace`> `exists`
     1. Click on **Preview** and **Save**.
 
     Screenshot shows this rule definition.

--- a/content/docs/0.2.0/monitoring/dynatrace/index.md
+++ b/content/docs/0.2.0/monitoring/dynatrace/index.md
@@ -84,7 +84,7 @@ When this script is finished, the Dynatrace OneAgent will be deployed in your cl
     1. Edit that rule:
         * Rule name: `Container.Namespace`
         * Process group name format: `{ProcessGroup:KubernetesContainerName}.{ProcessGroup:KubernetesNamespace}`
-        * Condition: `Kubernetes namespace`> `exits`
+        * Condition: `Kubernetes namespace`> `exists`
     1. Click on **Preview** and **Save**.
 
     Screenshot shows this rule definition.


### PR DESCRIPTION
Fix a few documentation typos from `exits` to `exists`