### PR TITLE
Update Elastic match query

### DIFF
--- a/content/docs/0.2.0/reference/keptnslog/index.md
+++ b/content/docs/0.2.0/reference/keptnslog/index.md
@@ -42,7 +42,7 @@ In case you want to export the keptn's log for debugging purposes, you can do so
   {
     "query": {
       "match": {
-        "keptnContext": "36ab658a-5933-4ff3-a079-d7205a339b0d"
+        "keptnContext": "<KEPTN_CONTEXT>"
       }
     },
     "size": 10000


### PR DESCRIPTION
Remove the unique ID to make it clear that users must use the KEPTN_CONTEXT from _their_ data.