### PR TITLE
#268 Removed instructions to configure Jenkins for DT monitoring

### DIFF
--- a/content/docs/develop/monitoring/dynatrace/index.md
+++ b/content/docs/develop/monitoring/dynatrace/index.md
@@ -48,29 +48,21 @@ In order to evaluate the quality gates, we have to set up monitoring to provide 
   ```console
   ./deployDynatrace.sh
   ```
+  When this script is finished, the Dynatrace OneAgent and the dynatrace-service are deployed in your cluster. Execute the following command to verify the deployment of the dynatrace-service.
 
-When this script is finished, the Dynatrace OneAgent will be deployed in your cluster.
+    ```console
+    kubectl get ksvc dynatrace-service -n keptn
 
-  **Note 1:** To see the services running in your cluster, make sure to restart the pods they are running in.
-  ```
-  kubectl delete pods --all -n keptn
-  ```
+    NAME                AGE
+    dynatrace-service   5m
+    ```
 
-  **Note 2:** If the nodes in your cluster run on *Container-Optimized OS (cos)*, make sure to [follow the instructions](https://www.dynatrace.com/support/help/cloud-platforms/google-cloud-platform/google-kubernetes-engine/deploy-oneagent-on-google-kubernetes-engine-clusters/#expand-134parameter-for-container-optimized-os-early-access) for setting up the Dynatrace OneAgent Operator. This means that after the initial setup with `deployDynatrace.sh`, which is a step below, the `cr.yml` has to be edited and applied again. In addition, all pods have to be restarted.
+**Note 1:** To monitor the services that are running, make sure to restart the pods.
+```console
+kubectl delete pods --all -n keptn
+```
 
-## Configure Jenkins
-
-1. Go to Jenkins at `http://jenkins.keptn.<EXTERNAL_IP>.xip.io/` and login with the default credentials `admin` / `AiTx4u8VyUV8tCKk` or with the updated credentials you set after the installation. You can retrieve the URL of Jenkins with the following command:
-  ```
-  echo http://jenkins.keptn.$(kubectl describe svc istio-ingressgateway -n istio-system | grep "LoadBalancer Ingress:" | sed 's~LoadBalancer Ingress:[ \t]*~~').xip.io/configure
-  ``` 
-  
-1. In the **Jenkins** > **Manage Jenkins** > **Configure System** screen, scroll to the environment variables and **Add** two new environment variables:
-    - `DT_TENANT_URL` with the Dynatrace tenant URL as value
-      -  Dynatrace SaaS tenant: `https://{your-environment-id}.live.dynatrace.com`
-      - Dynatrace-managed tenant: `https://{your-domain}/e/{your-environment-id}`
-    - `DT_API_TOKEN` with the Dynatrace API token as value
-  {{< popup_image link="./assets/jenkins-env-vars.png" caption="Jenkins environment variables">}}
+**Note 2:** If the nodes in your cluster run on *Container-Optimized OS (cos)*, make sure to [follow the instructions](https://www.dynatrace.com/support/help/cloud-platforms/google-cloud-platform/google-kubernetes-engine/deploy-oneagent-on-google-kubernetes-engine-clusters/#expand-134parameter-for-container-optimized-os-early-access) for setting up the Dynatrace OneAgent Operator. This means that after the initial setup with `deployDynatrace.sh`, which is a step below, the `cr.yml` has to be edited and applied again. In addition, all pods have to be restarted.
 
 ## (Optional) Create process group naming rule in Dynatrace
 


### PR DESCRIPTION
Due to the new dynatrace-service, the configuration of Jenkins for sending Dynatrace events is not needed anymore.