### PR TITLE
Use git clone --branch instead of cloning master

### DIFF
--- a/content/docs/0.2.0/monitoring/prometheus/index.md
+++ b/content/docs/0.2.0/monitoring/prometheus/index.md
@@ -13,7 +13,7 @@ In order to evaluate the quality gates, we have to set up monitoring to provide 
     - If you have not yet onboarded the carts service, please execute the following commands to receive the needed files:
         ```
         $ cd ~
-        $ git clone https://github.com/keptn/examples.git
+        $ git clone --branch 0.1.0 https://github.com/keptn/examples.git --single-branch
         $ cd ~/examples/monitoring/prometheus
         ```
 

--- a/content/docs/0.2.0/usecases/onboard-carts-service/index.md
+++ b/content/docs/0.2.0/usecases/onboard-carts-service/index.md
@@ -36,7 +36,7 @@ To illustrate the scenario this use case addresses, keptn relies on two services
 
     ```console
     $ cd ~
-    $ git clone https://github.com/keptn/examples.git
+    $ git clone --branch 0.1.0 https://github.com/keptn/examples.git --single-branch
     $ cd ~/examples/onboarding-carts
     ```
 

--- a/content/docs/0.2.1/monitoring/prometheus/index.md
+++ b/content/docs/0.2.1/monitoring/prometheus/index.md
@@ -13,7 +13,7 @@ In order to evaluate the quality gates, we have to set up monitoring to provide 
     - If you have not yet onboarded the carts service, please execute the following commands to receive the needed files:
         ```
         $ cd ~
-        $ git clone https://github.com/keptn/examples.git
+        $ git clone --branch 0.1.0 https://github.com/keptn/examples.git --single-branch
         $ cd ~/examples/monitoring/prometheus
         ```
 

--- a/content/docs/0.2.1/usecases/onboard-carts-service/index.md
+++ b/content/docs/0.2.1/usecases/onboard-carts-service/index.md
@@ -36,7 +36,7 @@ To illustrate the scenario this use case addresses, keptn relies on two services
 
     ```console
     cd ~
-    git clone https://github.com/keptn/examples.git
+    git clone --branch 0.1.0 https://github.com/keptn/examples.git --single-branch
     cd ~/examples/onboarding-carts
     ```
 

--- a/content/docs/develop/monitoring/prometheus/index.md
+++ b/content/docs/develop/monitoring/prometheus/index.md
@@ -13,7 +13,7 @@ In order to evaluate the quality gates, we have to set up monitoring to provide 
     - If you have not yet onboarded the carts service, please execute the following commands to receive the needed files:
     
     ```
-    git clone https://github.com/keptn/examples.git
+    git clone --branch 0.2.0 https://github.com/keptn/examples.git --single-branch
     cd ./examples/monitoring/prometheus
     ```
 

--- a/content/docs/develop/usecases/onboard-carts-service/index.md
+++ b/content/docs/develop/usecases/onboard-carts-service/index.md
@@ -35,7 +35,7 @@ To illustrate the scenario this use case addresses, keptn relies on two services
 1. Git clone artifacts for this use case.
 
     ```console
-    git clone https://github.com/keptn/examples.git
+    git clone --branch 0.2.0 https://github.com/keptn/examples.git --single-branch
     cd examples/onboarding-carts
     ```
 


### PR DESCRIPTION
Instead of cloning master, it is necessary to clone a tag (branch).