### PR TITLE
#387 Fixed typo: Changed artefact to artifact

### DIFF
--- a/content/docs/develop/installation/setup-keptn-gke/index.md
+++ b/content/docs/develop/installation/setup-keptn-gke/index.md
@@ -115,7 +115,7 @@ in the version of the latest release.
                     <li>deployment-finished</li>
                     <li>evaluation-done</li>
                     <li>keptn-channel</li>
-                    <li>new-artefact</li>
+                    <li>new-artifact</li>
                     <li>problem</li>
                     <li>tests-finished</li>
                 </ul>
@@ -211,7 +211,7 @@ in the version of the latest release.
   deployment-finished     31m
   evaluation-done         31m
   keptn-channel           31m
-  new-artefact            31m
+  new-artifact            31m
   problem                 31m
   start-deployment        31m
   start-evaluation        31m

--- a/content/docs/develop/reference/custom-service/index.md
+++ b/content/docs/develop/reference/custom-service/index.md
@@ -60,7 +60,7 @@ Services in keptn are implemented as [knative services](https://cloud.google.com
   apiVersion: eventing.knative.dev/v1alpha1
   kind: Subscription
   metadata:
-    name: github-new-artefict-subscription
+    name: github-new-artifact-subscription
     namespace: keptn
   spec:
     channel:

--- a/content/docs/develop/reference/custom-service/index.md
+++ b/content/docs/develop/reference/custom-service/index.md
@@ -13,7 +13,7 @@ Shows you how to implement your own keptn service and listen for certain events.
 The goal of this section is to describe how you can add additional functionality to your keptn installation by implementing your own services. 
 You can react to certain events that occur during your CD pipeline runs, and, integrate additional tools into your pipeline by accessing their REST interfaces with your custom services. At the moment the events you can subscribe to include:
 
-- sh.keptn.events.new-artefact
+- sh.keptn.events.new-artifact
 - sh.keptn.events.configuration-changed
 - sh.keptn.events.deployment-finished
 - sh.keptn.events.tests-finished
@@ -60,13 +60,13 @@ Services in keptn are implemented as [knative services](https://cloud.google.com
   apiVersion: eventing.knative.dev/v1alpha1
   kind: Subscription
   metadata:
-    name: github-new-artefact-subscription
+    name: github-new-artefict-subscription
     namespace: keptn
   spec:
     channel:
       apiVersion: eventing.knative.dev/v1alpha1
       kind: Channel
-      name: new-artefact
+      name: new-artifact
     subscriber:
       ref:
         apiVersion: serving.knative.dev/v1alpha1
@@ -79,7 +79,7 @@ As you can see in the manifest file, it consists of a *knative service*, as well
 The *Subscription* defines to which kind of event the service should listen to. To subscribe your service to a queue, set the property *spec.channel.name* to one of the following:
 
   ```
-  new-artefact
+  new-artifact
   configuration-changed
   deployment-finished
   tests-finished
@@ -110,12 +110,12 @@ any previous revisions of the service will be deleted and the newest version wil
 
 Depending on the channel your service is subscribed to, it will receive the payload in the following format:
 
-### sh.keptn.new-artefact
+### sh.keptn.new-artifact
 
 ```json
 {  
    "specversion":"0.2",
-   "type":"sh.keptn.events.new-artefact",
+   "type":"sh.keptn.events.new-artifact",
    "source":"Jenkins",
    "id":"1234",
    "time":"20190325-15:26:52.036",

--- a/content/docs/develop/reference/keptnslog/index.md
+++ b/content/docs/develop/reference/keptnslog/index.md
@@ -23,7 +23,7 @@ Setup keptns log within the **Configure an index pattern** page:
 
 ## Analyzing pipeline runs
 
-Keptn summarizes logs for a specific pipeline run by adding a property called `keptnContext` to the log messages of the services that participate during a pipeline run for a new artefact. To retrieve the `keptnContext` for a pipeline run, do the following:
+Keptn summarizes logs for a specific pipeline run by adding a property called `keptnContext` to the log messages of the services that participate during a pipeline run for a new artifact. To retrieve the `keptnContext` for a pipeline run, do the following:
 
   1. Navigate to the <a href="http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_g=()&_a=(columns:!(keptnService,message,logLevel,keptnContext),index:AWmaEz7MZe0TiwRXPS-e,interval:auto,query:(query_string:(analyze_wildcard:!t,query:'keptnEntry:%20true')),sort:!('@timestamp',desc))">Discover</a> view in Kibana (Please use that specific link, as that one already contains the ideal formatting configuration).
     


### PR DESCRIPTION
This PR ensures a consistent use of the word artifact instead of artefact across all keptn repositories.