### PR TITLE
Adjusting DT instructions due to move of scripts

### DIFF
--- a/content/docs/develop/monitoring/dynatrace/index.md
+++ b/content/docs/develop/monitoring/dynatrace/index.md
@@ -38,7 +38,7 @@ In order to evaluate the quality gates and allow self-healing in production, we 
 1. Clone the install repository and setup your credentials by executing the following steps:
 ```console
 git clone --branch 0.1.2 https://github.com/keptn/dynatrace-service --single-branch
-cd deploy/scripts
+cd dynatrace-service/deploy/scripts
 ./defineDynatraceCredentials.sh
 ```
   When the  script asks for your Dynatrace tenant, please enter your tenant according to the appropriate pattern:

--- a/content/docs/develop/monitoring/dynatrace/index.md
+++ b/content/docs/develop/monitoring/dynatrace/index.md
@@ -37,8 +37,8 @@ In order to evaluate the quality gates and allow self-healing in production, we 
 
 1. Clone the install repository and setup your credentials by executing the following steps:
 ```console
-git clone --branch 0.2.2 https://github.com/keptn/installer --single-branch
-cd installer/scripts
+git clone --branch 0.1.2 https://github.com/keptn/dynatrace-service --single-branch
+cd deploy/scripts
 ./defineDynatraceCredentials.sh
 ```
   When the  script asks for your Dynatrace tenant, please enter your tenant according to the appropriate pattern:


### PR DESCRIPTION
Scripts to deploy DT have been moved. Thus, it is necessary to adjust the instructions accordingly.