### PR TITLE
#415 Removed start-* channels

### DIFF
--- a/content/docs/0.2.1/installation/setup-keptn-gke/index.md
+++ b/content/docs/0.2.1/installation/setup-keptn-gke/index.md
@@ -257,16 +257,14 @@ kubectl delete pod $(
   ```
 
   ```console
-  configuration-changed   10d
-  deployment-finished     10d
-  evaluation-done         10d
-  keptn-channel           10d
-  new-artefact            10d
-  problem                 10d
-  start-deployment        10d
-  start-evaluation        10d
-  start-tests             10d
-  tests-finished          10d
+  NAME                    AGE
+  configuration-changed   16m
+  deployment-finished     16m
+  evaluation-done         16m
+  keptn-channel           16m
+  new-artefact            16m
+  problem                 16m
+  tests-finished          16m
   ```
 
   If that is not the case, there may have been a problem during the installation. In that case we kindly ask you to clean your cluster and restart the installation, as described in the **Troubleshooting** section below.

--- a/content/docs/0.2.2/installation/setup-keptn-gke/index.md
+++ b/content/docs/0.2.2/installation/setup-keptn-gke/index.md
@@ -213,9 +213,6 @@ in the version of the latest release.
   keptn-channel           31m
   new-artefact            31m
   problem                 31m
-  start-deployment        31m
-  start-evaluation        31m
-  start-tests             31m
   tests-finished          31m
   ```
 

--- a/content/docs/develop/installation/setup-keptn-gke/index.md
+++ b/content/docs/develop/installation/setup-keptn-gke/index.md
@@ -213,9 +213,6 @@ in the version of the latest release.
   keptn-channel           31m
   new-artifact            31m
   problem                 31m
-  start-deployment        31m
-  start-evaluation        31m
-  start-tests             31m
   tests-finished          31m
   ```
 


### PR DESCRIPTION
This PR updates the installation instructions. The result of the command `kubectl get channels -n keptn` showed a wrong list of channels because keptn 0.2.0, 0.2.1 and 0.2.2 don`t deploy start-* channels.
