### PR TITLE
Added instructions to upgrade Dynatrace secret

### DIFF
--- a/content/docs/0.2.2/installation/upgrade-keptn-gke/index.md
+++ b/content/docs/0.2.2/installation/upgrade-keptn-gke/index.md
@@ -121,3 +121,7 @@ Due to a breaking change from keptn 0.2.1 to 0.2.2 regarding the naming conventi
 - Instructions for creating a project are provided [here](../../usecases/onboard-carts-service/#create-project-sockshop).
 
 - Instructions for onboarding a service are provided [here](../../usecases/onboard-carts-service/#onboard-carts-service-and-carts-database).
+
+## Upgrade monitoring
+
+If Dynatrace is used for monitoring, please follow the upgrade instructions [here](../../monitoring/dynatrace/#upgrade-dynatrace-monitoring-for-keptn-0.2.2).

--- a/content/docs/0.2.2/monitoring/dynatrace/index.md
+++ b/content/docs/0.2.2/monitoring/dynatrace/index.md
@@ -77,6 +77,16 @@ The Dynatrace service will take care of pushing events of the keptn workflow to 
     caption="keptn events"
     width="500px">}}
 
+## Upgrade Dynatrace monitoring for keptn 0.2.2
+
+Due to a change of the data stored in the `dynatrace` secret in the `keptn` namespace, it is necessary to update the secret according to the following steps:
+  1. Prepare the Dynatrace URI:
+      - Dynatrace SaaS tenant: `{your-environment-id}.live.dynatrace.com`
+      - Dynatrace-managed tenant: `{your-domain}/e/{your-environment-id}`
+  1. Update the property `DT_TENANT` based on the Dynatrace URI. Please note that the value has to be base64 encoded.
+      ```console
+      kubectl edit secret dynatrace -n keptn     
+      ```
 
 ## (Optional) Create process group naming rule in Dynatrace
 
@@ -93,4 +103,3 @@ The Dynatrace service will take care of pushing events of the keptn workflow to 
     {{< popup_image
     link="./assets/pg_naming.png"
     caption="Dynatrace naming rule">}}
-

--- a/content/docs/develop/reference/cli/index.md
+++ b/content/docs/develop/reference/cli/index.md
@@ -253,7 +253,7 @@ keptn onboard service --project=your_project --values=values.yaml
 keptn onboard service --project=your_project --values=values.yaml --deployment=deployment.yaml --service=service.yaml
 ```
 
-**Note:** If you would like to have the environment variables `KEPTN_PROJECT`, `KEPTN_STAGE`, and `KEPTN_SERVICE` within your service, add the following environment variables to your deployment configuration.
+**Note:** If you are using custom configurations and you would like to have the environment variables `KEPTN_PROJECT`, `KEPTN_STAGE`, and `KEPTN_SERVICE` within your service, add the following environment variables to your deployment configuration.
 
   ```yaml
   env:


### PR DESCRIPTION
When upgrading keptn from 0.2.x to 0.2.2, it is necessary to update dynatrace secret.