### PR TITLE
More information about community meetings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 public
 resources/_gen/**/*.content
 .DS_Store
+
+# IDE files
+.idea/
+.vscode/

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -4,12 +4,7 @@ date: 2019-02-21T15:37:57+07:00
 menu: main
 ---
 
-Keptn is an _open source enterprise-grade framework for shipping and
+Keptn is an _opinionated open-source enterprise-grade framework for shipping and
 running cloud-native applications_ and curated by [Dynatrace](https://dynatrace.com).
 
-## Get in Touch
-
-- Send an email: keptn@dynatrace.com
-- Join us on Slack: [keptn.slack.com](https://join.slack.com/t/keptn/shared_invite/enQtNTUxMTQ1MzgzMzUxLTcxMzE0OWU1YzU5YjY3NjFhYTJlZTNjOTZjY2EwYzQyYWRkZThhY2I3ZDMzN2MzOThkZjIzOTdhOGViMDNiMzI)
-- Follow us on Twitter: [keptnProject](https://twitter.com/keptnProject)
-- Be part of the movement and participate in our [community meetings](https://github.com/keptn/community)
+Feel free to review the source code within our [Keptn Github Organization](https://github.com/keptn/).

--- a/content/get-in-touch/index.md
+++ b/content/get-in-touch/index.md
@@ -1,0 +1,14 @@
+---
+title: 'Get in touch'
+date: 2019-10-08T12:33:32+02:00
+menu: main
+---
+
+Any questions? Whether you are an end-user with a strong opinion or you want to participate in the project, we'd love to hear from you!
+
+- Join us on Slack: [keptn.slack.com](https://join.slack.com/t/keptn/shared_invite/enQtNTUxMTQ1MzgzMzUxLWMzNmM1NDc4MmE0MmQ0MDgwYzMzMDc4NjM5ODk0ZmFjNTE2YzlkMGE4NGU5MWUxODY1NTBjNjNmNmI1NWQ1NGY)
+- Follow us on Twitter: [keptnProject](https://twitter.com/keptnProject)
+- Be part of the movement and participate in our public community meetings every other Monday ([public google calendar](https://calendar.google.com/calendar/embed?src=dynatrace.com_abjrh1ukf18ih477tb1ekag2ag%40group.calendar.google.com), [ical](https://calendar.google.com/calendar/ical/dynatrace.com_abjrh1ukf18ih477tb1ekag2ag%40group.calendar.google.com/public/basic.ics))
+- Send us an email: keptn@dynatrace.com
+
+You can find more information in the [keptn community repo](https://github.com/keptn/community).


### PR DESCRIPTION
Right now the information about how to get in touch is hidden within the About section and within the keptn/community repo.

I believe making this information more prominent can help to get more people on board of the project.

I've also edited the slack invite link (similar to https://github.com/keptn/community/commit/7f96d1fe26c7d17176e78234352e6a149ee58b5d ).

Also, I've added .idea/ and .vscode/ to .gitignore.