### PR TITLE
fix Eks cluster size & mongo version

### DIFF
--- a/content/docs/0.6.0/installation/setup-keptn/index.md
+++ b/content/docs/0.6.0/installation/setup-keptn/index.md
@@ -39,7 +39,7 @@ Select one of the following options:
   - Sample script using [eksctl](https://eksctl.io/introduction/installation/) to create such a cluster
 
     ```console
-    eksctl create cluster --version=1.13 --name=keptn-cluster --node-type=m5.xlarge --nodes=1 --region=eu-west-3
+    eksctl create cluster --version=1.13 --name=keptn-cluster --node-type=m5.2xlarge --nodes=1 --region=eu-west-3
     ```
     In our testing we learned that the default CoreDNS that comes with certain EKS versions has a bug. In order to solve that issue we can use eksctl to update the CoreDNS service like this: 
     ```console

--- a/content/docs/0.6.0/usecases/onboard-carts-service/index.md
+++ b/content/docs/0.6.0/usecases/onboard-carts-service/index.md
@@ -168,7 +168,7 @@ After onboarding the services, a built artifact of each service can be deployed.
 * Deploy the carts-db service by executing the [keptn send event new-artifact](../../reference/cli/#keptn-send-event-new-artifact) command:
 
   ```console
-  keptn send event new-artifact --project=sockshop --service=carts-db --image=mongo
+  keptn send event new-artifact --project=sockshop --service=carts-db --image=mongo:4.2.2
   ```
 
 * Deploy the carts service by specifying the built artifact, which is stored on DockerHub and tagged with version 0.10.1:


### PR DESCRIPTION
- increased EKS cluster size to to have 8 vCPUs available
- set mongo version to a fixed version instead of fetching latest