### PR TITLE
Remove GKE_VERSION

### DIFF
--- a/content/docs/quickstart/setup_platform/setup_gke/index.md
+++ b/content/docs/quickstart/setup_platform/setup_gke/index.md
@@ -10,7 +10,7 @@ keywords: setup
   - [python 2.7](https://www.python.org/downloads/release/python-2716/) (required for Ubuntu 19.04)
 
 ## 2a. Create GKE cluster through Cloud Console
-  - Master version >= `1.11.x` (`1.12.8-gke.10`)
+  - Master version >= `1.11.x`
   - One `n1-standard-4` node
   - Image type `ubuntu` or `cos` (if you plan to use Dynatrace monitoring, select `ubuntu` for a more [convenient setup](../../monitoring/dynatrace/))
   - Sample script to create such cluster (adapt the values according to your needs)
@@ -22,9 +22,8 @@ PROJECT=nameofgcloudproject
 CLUSTER_NAME=nameofcluster
 ZONE=us-central1-a
 REGION=us-central1
-GKE_VERSION="1.12.8-gke.10"
 ```
 
 ```console
-gcloud beta container --project $PROJECT clusters create $CLUSTER_NAME --zone $ZONE --no-enable-basic-auth --cluster-version $GKE_VERSION --machine-type "n1-standard-4" --image-type "UBUNTU" --disk-type "pd-standard" --disk-size "100" --metadata disable-legacy-endpoints=true --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --num-nodes "1" --enable-cloud-logging --enable-cloud-monitoring --no-enable-ip-alias --network "projects/$PROJECT/global/networks/default" --subnetwork "projects/$PROJECT/regions/$REGION/subnetworks/default" --addons HorizontalPodAutoscaling,HttpLoadBalancing --no-enable-autoupgrade
+gcloud beta container --project $PROJECT clusters create $CLUSTER_NAME --zone $ZONE --no-enable-basic-auth --machine-type "n1-standard-4" --image-type "UBUNTU" --disk-type "pd-standard" --disk-size "100" --metadata disable-legacy-endpoints=true --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --num-nodes "1" --enable-cloud-logging --enable-cloud-monitoring --no-enable-ip-alias --network "projects/$PROJECT/global/networks/default" --subnetwork "projects/$PROJECT/regions/$REGION/subnetworks/default" --addons HorizontalPodAutoscaling,HttpLoadBalancing --no-enable-autoupgrade
 ```


### PR DESCRIPTION
Remove GKE_VERSION command as 1.12.8-gke.10 is unsupported.
When executed, error is `ERROR: (gcloud.beta.container.clusters.create) ResponseError: code=400, message=Master version "1.12.8-gke.10" is unsupported.`

Let Google chose the default.