### PR TITLE
Update kubernetes versions and cluster sizes

### DIFF
--- a/content/docs/0.5.0/installation/setup-keptn/index.md
+++ b/content/docs/0.5.0/installation/setup-keptn/index.md
@@ -35,7 +35,7 @@ Select one of the following options:
 
 1. Create EKS cluster on AWS
   - version >= `1.13` (tested version: `1.13`)
-  - One `m5.xlarge` node
+  - One `m5.2xlarge` node
   - Sample script using [eksctl](https://eksctl.io/introduction/installation/) to create such a cluster
 
     ```console

--- a/content/docs/quickstart/_index.md
+++ b/content/docs/quickstart/_index.md
@@ -8,6 +8,8 @@ weight: 1
 
 ### 1. Setup your platform
 
+**Note**: For running the tutorials with Keptn 0.5 and newer we recommend having at least **6 vCPUs** and **12 GB memory**.
+
 * [Preparing Azure Kubernetes Engine (AKS)](/docs/quickstart/setup_platform/setup_aks)
 * [Preparing Amazon Elastic Kubernetes Service (EKS)](/docs/quickstart/setup_platform/setup_eks)
 * [Preparing Google Kubernetes Engine (GKE)](/docs/quickstart/setup_platform/setup_gke)

--- a/content/docs/quickstart/setup_platform/setup_eks/index.md
+++ b/content/docs/quickstart/setup_platform/setup_eks/index.md
@@ -10,4 +10,4 @@ keywords: setup
 
 ## 2. Create EKS cluster
   - version >= `1.13` (tested version: `1.13`)
-  - One `m5.xlarge` node
+  - One `m5.2xlarge` node

--- a/content/docs/quickstart/setup_platform/setup_gke/index.md
+++ b/content/docs/quickstart/setup_platform/setup_gke/index.md
@@ -10,8 +10,8 @@ keywords: setup
   - [python 2.7](https://www.python.org/downloads/release/python-2716/) (required for Ubuntu 19.04)
 
 ## 2a. Create GKE cluster through Cloud Console
-  - Master version >= `1.11.x` (`1.12.8-gke.10`)
-  - One `n1-standard-4` node
+  - Master version >= `1.13.x` (tested with `1.13.11-gke.14`)
+  - One `n1-standard-8` node (or two `n1-standard-4` nodes)
   - Image type `ubuntu` or `cos` (if you plan to use Dynatrace monitoring, select `ubuntu` for a more [convenient setup](../../monitoring/dynatrace/))
   - Sample script to create such cluster (adapt the values according to your needs)
 
@@ -22,9 +22,9 @@ PROJECT=nameofgcloudproject
 CLUSTER_NAME=nameofcluster
 ZONE=us-central1-a
 REGION=us-central1
-GKE_VERSION="1.12.8-gke.10"
+GKE_VERSION="1.13.11-gke.14"
 ```
 
 ```console
-gcloud beta container --project $PROJECT clusters create $CLUSTER_NAME --zone $ZONE --no-enable-basic-auth --cluster-version $GKE_VERSION --machine-type "n1-standard-4" --image-type "UBUNTU" --disk-type "pd-standard" --disk-size "100" --metadata disable-legacy-endpoints=true --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --num-nodes "1" --enable-cloud-logging --enable-cloud-monitoring --no-enable-ip-alias --network "projects/$PROJECT/global/networks/default" --subnetwork "projects/$PROJECT/regions/$REGION/subnetworks/default" --addons HorizontalPodAutoscaling,HttpLoadBalancing --no-enable-autoupgrade
+gcloud beta container --project $PROJECT clusters create $CLUSTER_NAME --zone $ZONE --no-enable-basic-auth --cluster-version $GKE_VERSION --machine-type "n1-standard-8" --image-type "UBUNTU" --disk-type "pd-standard" --disk-size "100" --metadata disable-legacy-endpoints=true --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --num-nodes "1" --enable-cloud-logging --enable-cloud-monitoring --no-enable-ip-alias --network "projects/$PROJECT/global/networks/default" --subnetwork "projects/$PROJECT/regions/$REGION/subnetworks/default" --addons HorizontalPodAutoscaling,HttpLoadBalancing --no-enable-autoupgrade
 ```

--- a/content/home/kubernetes-cluster-top.md
+++ b/content/home/kubernetes-cluster-top.md
@@ -1,1 +1,1 @@
-## Keptn only requires a plain Kubernetes cluster (version >1.13)
+## Keptn only requires a plain Kubernetes cluster (versions 1.13, 1.14, 1.15)


### PR DESCRIPTION
As an alternative to #412, I've updated Kubernetes versions and VM sizes for quickstart and 0.5.x