### PR TITLE
Make sure Keptn's Bridge is always written with a capital B and K

### DIFF
--- a/content/docs/0.5.0/concepts/architecture/index.md
+++ b/content/docs/0.5.0/concepts/architecture/index.md
@@ -43,9 +43,9 @@ The *mongodb-datastore* provides means to store event and log data in a mongodb 
 
 ### bridge
 
-The *Keptn's bridge* lets a user browse the Keptn's log by providing a user interface that shows all Keptn events and log messages correlated to those events.
+The *Keptn's Bridge* lets a user browse the Keptn's log by providing a user interface that shows all Keptn events and log messages correlated to those events.
 
-**Note:** A dedicated section for the Keptn's bridge is provided [here](../../reference/keptnsbridge/), which explains how to access it and shows the user interface.
+**Note:** A dedicated section for the Keptn's Bridge is provided [here](../../reference/keptnsbridge/), which explains how to access it and shows the user interface.
 
 ### configuration-service
 

--- a/content/docs/0.5.0/reference/keptnsbridge/index.md
+++ b/content/docs/0.5.0/reference/keptnsbridge/index.md
@@ -1,15 +1,15 @@
 ---
-title: Keptn's bridge
-description: Explains how the access the Keptn's bridge.
+title: Keptn's Bridge
+description: Explains how the access the Keptn's Bridge.
 weight: 21
 keywords: [bridge]
 ---
 
-The Keptn's bridge lets you browse the Keptn's log. It is automatically installed with your Keptn installation.
+The Keptn's Bridge lets you browse the Keptn's log. It is automatically installed with your Keptn installation.
 
 ## Usage
 
-The Keptn's bridge is not publicly accessible, but can be retrieved by enabling port-forwarding from your local machine to the Keptn's bridge:
+The Keptn's Bridge is not publicly accessible, but can be retrieved by enabling port-forwarding from your local machine to the Keptn's Bridge:
 
 ```console
 kubectl port-forward svc/bridge -n keptn 9000:8080
@@ -17,15 +17,15 @@ kubectl port-forward svc/bridge -n keptn 9000:8080
 
 It is then available on: http://localhost:9000.
 
-The Keptn's bridge provides an easy way to browse all events that are sent within Keptn and to filter on a specific Keptn context. When you access the Keptn's bridge, all Keptn entry points will be listed in the left column. Please note that this list only represents the start of a deployment of a new artifact and, thus, more information on the executed steps can be revealed when you click on one event.
+The Keptn's Bridge provides an easy way to browse all events that are sent within Keptn and to filter on a specific Keptn context. When you access the Keptn's Bridge, all Keptn entry points will be listed in the left column. Please note that this list only represents the start of a deployment of a new artifact and, thus, more information on the executed steps can be revealed when you click on one event.
 
   {{< popup_image
   link="./assets/bridge_empty.png"
-  caption="Keptn's bridge start page">}}
+  caption="Keptn's Bridge start page">}}
 
-When selecting an event, the Keptn's bridge displays all other events that are in the same Keptn context and, thus, belong to the selected entry point. As can be seen in the screenshot below, the entry point around 4:22pm has been selected and all events belonging to this entry point are shown. The detail section lists the _timestamp_ as well as _payload_ of the event. Additionally, the _service_ that sent this event is also shown.
+When selecting an event, the Keptn's Bridge displays all other events that are in the same Keptn context and, thus, belong to the selected entry point. As can be seen in the screenshot below, the entry point around 4:22pm has been selected and all events belonging to this entry point are shown. The detail section lists the _timestamp_ as well as _payload_ of the event. Additionally, the _service_ that sent this event is also shown.
 
   {{< popup_image
   link="./assets/bridge_details.png"
-  caption="Keptn's bridge detailed view">}}
+  caption="Keptn's Bridge detailed view">}}
 

--- a/content/docs/0.5.0/usecases/deployments-with-quality-gates/index.md
+++ b/content/docs/0.5.0/usecases/deployments-with-quality-gates/index.md
@@ -146,7 +146,7 @@ After triggering the deployment of the carts service in version v0.9.2, the foll
   * To verify, open a browser and navigate to: `http://carts.sockshop-dev.YOUR.DOMAIN`
 
 * **Staging stage:** In this stage, version v0.9.2 will be deployed and the performance test starts to run for about 10 minutes. After the test is completed, Keptn triggers the test evaluation and identifies the slowdown. Consequently, a roll-back to version v0.9.1 in this stage is conducted and the promotion to production is not triggered.
-  * To verify, the [Keptn's bridge](../../reference/keptnsbridge/#usage) shows the deployment of v0.9.2 and then the failed test in staging including the roll-back:
+  * To verify, the [Keptn's Bridge](../../reference/keptnsbridge/#usage) shows the deployment of v0.9.2 and then the failed test in staging including the roll-back:
 
     {{< popup_image
       link="./assets/quality_gates.png"

--- a/content/docs/0.5.0/usecases/onboard-carts-service/index.md
+++ b/content/docs/0.5.0/usecases/onboard-carts-service/index.md
@@ -176,19 +176,19 @@ After onboarding the services, a built artifact of each service can be deployed.
   keptn send event new-artifact --project=sockshop --service=carts --image=docker.io/keptnexamples/carts --tag=0.9.1
   ```
 
-* Go to Keptn's bridge and check which events have already been generated. You can access it by a port-forward from your local machine to the Kubernetes cluster:
+* Go to Keptn's Bridge and check which events have already been generated. You can access it by a port-forward from your local machine to the Kubernetes cluster:
 
   ```console 
   kubectl port-forward svc/bridge -n keptn 9000:8080
   ```
 
-* The Keptn's bridge is then available on: http://localhost:9000. 
+* The Keptn's Bridge is then available on: http://localhost:9000. 
 
-    It shows all deployments that have been triggered. On the left-hand side you can see the deployment start events (i.e., so-called `Configuration change` events). During a deployment, Keptn generates events for controlling the deployment process. These events will also show up in Keptn's bridge. Please note that if events are sent at the same time, their order in the Keptn's bridge might be arbitrary since they are sorted on the granularity of one second. 
+    It shows all deployments that have been triggered. On the left-hand side you can see the deployment start events (i.e., so-called `Configuration change` events). During a deployment, Keptn generates events for controlling the deployment process. These events will also show up in Keptn's Bridge. Please note that if events are sent at the same time, their order in the Keptn's Bridge might be arbitrary since they are sorted on the granularity of one second. 
 
     {{< popup_image
       link="./assets/bridge.png"
-      caption="Keptn's bridge">}}
+      caption="Keptn's Bridge">}}
 
 ## View carts service
 

--- a/content/docs/0.5.0/usecases/self-healing-with-keptn/index.md
+++ b/content/docs/0.5.0/usecases/self-healing-with-keptn/index.md
@@ -219,5 +219,5 @@ In this tutorial, the number of pods will be increased to remediate the issue of
     
     {{< popup_image
     link="./assets/bridge_remediation.png"
-    caption="Keptn's bridge">}}
+    caption="Keptn's Bridge">}}
 

--- a/content/docs/0.6.0/concepts/architecture/index.md
+++ b/content/docs/0.6.0/concepts/architecture/index.md
@@ -43,9 +43,9 @@ The *mongodb-datastore* provides means to store event and log data in a mongodb 
 
 ### bridge
 
-The *Keptn's bridge* lets a user browse the Keptn's log by providing a user interface that shows all Keptn events and log messages correlated to those events.
+The *Keptn's Bridge* lets a user browse the Keptn's log by providing a user interface that shows all Keptn events and log messages correlated to those events.
 
-**Note:** A dedicated section for the Keptn's bridge is provided [here](../../reference/keptnsbridge/), which explains how to access it and shows the user interface.
+**Note:** A dedicated section for the Keptn's Bridge is provided [here](../../reference/keptnsbridge/), which explains how to access it and shows the user interface.
 
 ### configuration-service
 

--- a/content/docs/0.6.0/reference/keptnsbridge/index.md
+++ b/content/docs/0.6.0/reference/keptnsbridge/index.md
@@ -1,15 +1,15 @@
 ---
-title: Keptn's bridge
-description: Explains how the access the Keptn's bridge.
+title: Keptn's Bridge
+description: Explains how the access the Keptn's Bridge.
 weight: 21
 keywords: [bridge]
 ---
 
-The Keptn's bridge lets you browse the Keptn's log. It is automatically installed with your Keptn installation.
+The Keptn's Bridge lets you browse the Keptn's log. It is automatically installed with your Keptn installation.
 
 ## Usage
 
-The Keptn's bridge is not publicly accessible, but can be retrieved by enabling port-forwarding from your local machine to the Keptn's bridge:
+The Keptn's Bridge is not publicly accessible, but can be retrieved by enabling port-forwarding from your local machine to the Keptn's Bridge:
 
 ```console
 kubectl port-forward svc/bridge -n keptn 9000:8080
@@ -17,19 +17,19 @@ kubectl port-forward svc/bridge -n keptn 9000:8080
 
 It is then available on: http://localhost:9000.
 
-The Keptn's bridge provides an easy way to browse all events that are sent within Keptn and to filter on a specific Keptn context. When you access the Keptn's bridge, all Keptn entry points will be listed in the left column. Please note that this list only represents the start of a deployment of a new artifact and, thus, more information on the executed steps can be revealed when you click on one event.
+The Keptn's Bridge provides an easy way to browse all events that are sent within Keptn and to filter on a specific Keptn context. When you access the Keptn's Bridge, all Keptn entry points will be listed in the left column. Please note that this list only represents the start of a deployment of a new artifact and, thus, more information on the executed steps can be revealed when you click on one event.
 
   {{< popup_image
   link="./assets/bridge_empty.png"
-  caption="Keptn's bridge start page">}}
+  caption="Keptn's Bridge start page">}}
 
-When selecting an event, the Keptn's bridge displays all other events that are in the same Keptn context and, thus, belong to the selected entry point. As can be seen in the screenshot below, the entry point around 4:22 pm has been selected and all events belonging to this entry point are shown. The detail section lists the _timestamp_ as well as _payload_ of the event. Additionally, the _service_ that sent this event is also shown.
+When selecting an event, the Keptn's Bridge displays all other events that are in the same Keptn context and, thus, belong to the selected entry point. As can be seen in the screenshot below, the entry point around 4:22 pm has been selected and all events belonging to this entry point are shown. The detail section lists the _timestamp_ as well as _payload_ of the event. Additionally, the _service_ that sent this event is also shown.
 
   {{< popup_image
   link="./assets/bridge_details.png"
-  caption="Keptn's bridge detailed view">}}
+  caption="Keptn's Bridge detailed view">}}
 
-**Please note**: Keptn's bridge exposes sensitive information. We do not recommend exposing it publicly via LoadBalancer, NodePort, VirtualServices or alike.
+**Please note**: Keptn's Bridge exposes sensitive information. We do not recommend exposing it publicly via LoadBalancer, NodePort, VirtualServices or alike.
 
 
 ## Early Access Version of Keptn's Bridge

--- a/content/docs/0.6.0/usecases/deployments-with-quality-gates/index.md
+++ b/content/docs/0.6.0/usecases/deployments-with-quality-gates/index.md
@@ -176,7 +176,7 @@ After triggering the deployment of the carts service in version v0.10.2, the fol
   * To verify, open a browser and navigate to: `http://carts.sockshop-dev.YOUR.DOMAIN`
 
 * **Staging stage:** In this stage, version v0.10.2 will be deployed and the performance test starts to run for about 10 minutes. After the test is completed, Keptn triggers the test evaluation and identifies the slowdown. Consequently, a roll-back to version v0.10.1 in this stage is conducted and the promotion to production is not triggered.
-  * To verify, the [Keptn's bridge](../../reference/keptnsbridge/#usage) shows the deployment of v0.10.2 and then the failed test in staging including the roll-back:
+  * To verify, the [Keptn's Bridge](../../reference/keptnsbridge/#usage) shows the deployment of v0.10.2 and then the failed test in staging including the roll-back:
 
     {{< popup_image
       link="./assets/quality_gates.png"

--- a/content/docs/0.6.0/usecases/onboard-carts-service/index.md
+++ b/content/docs/0.6.0/usecases/onboard-carts-service/index.md
@@ -177,19 +177,19 @@ keptn send event new-artifact --project=sockshop --service=carts-db --image=mong
 keptn send event new-artifact --project=sockshop --service=carts --image=docker.io/keptnexamples/carts --tag=0.10.1
 ```
 
-* Go to Keptn's bridge and check which events have already been generated. You can access it by a port-forward from your local machine to the Kubernetes cluster:
+* Go to Keptn's Bridge and check which events have already been generated. You can access it by a port-forward from your local machine to the Kubernetes cluster:
 
 ```console 
 kubectl port-forward svc/bridge -n keptn 9000:8080
 ```
 
-* The Keptn's bridge is then available on: http://localhost:9000. 
+* The Keptn's Bridge is then available on: http://localhost:9000. 
 
-    It shows all deployments that have been triggered. On the left-hand side, you can see the deployment start events (i.e., so-called `Configuration change` events). During a deployment, Keptn generates events for controlling the deployment process. These events will also show up in Keptn's bridge. Please note that if events are sent at the same time, their order in the Keptn's bridge might be arbitrary since they are sorted on the granularity of one second. 
+    It shows all deployments that have been triggered. On the left-hand side, you can see the deployment start events (i.e., so-called `Configuration change` events). During a deployment, Keptn generates events for controlling the deployment process. These events will also show up in Keptn's Bridge. Please note that if events are sent at the same time, their order in the Keptn's Bridge might be arbitrary since they are sorted on the granularity of one second. 
 
     {{< popup_image
       link="./assets/bridge.png"
-      caption="Keptn's bridge">}}
+      caption="Keptn's Bridge">}}
 
 * **Optional:** Verify the pods that should have been created for services carts and carts-db:
 

--- a/content/docs/0.6.0/usecases/self-healing-with-keptn/dynatrace-scaling/index.md
+++ b/content/docs/0.6.0/usecases/self-healing-with-keptn/dynatrace-scaling/index.md
@@ -138,7 +138,7 @@ In this tutorial, the number of pods will be increased to remediate the issue of
     carts-primary-7c96d87df9-78fh2    2/2     Running   0          5m
     ```
 
-1. To get an overview of the actions that got triggered by the response time SLO violation, you can use the Keptn's bridge. You can access it by a port-forward from your local machine to the Kubernetes cluster:
+1. To get an overview of the actions that got triggered by the response time SLO violation, you can use the Keptn's Bridge. You can access it by a port-forward from your local machine to the Kubernetes cluster:
 
     ```console 
     kubectl port-forward svc/bridge -n keptn 9000:8080
@@ -150,7 +150,7 @@ In this tutorial, the number of pods will be increased to remediate the issue of
     
     {{< popup_image
     link="./assets/bridge_remediation.png"
-    caption="Keptn's bridge">}}
+    caption="Keptn's Bridge">}}
     
 1. Furthermore, you can see how the response time of the service decreased by viewing the time series chart in Dynatrace:
 
@@ -159,4 +159,4 @@ In this tutorial, the number of pods will be increased to remediate the issue of
 
     {{< popup_image
     link="./assets/dt-problem-closed.png"
-    caption="Keptn's bridge">}}
+    caption="Keptn's Bridge">}}

--- a/content/docs/0.6.0/usecases/self-healing-with-keptn/prometheus-scaling/index.md
+++ b/content/docs/0.6.0/usecases/self-healing-with-keptn/prometheus-scaling/index.md
@@ -144,7 +144,7 @@ In this tutorial, the number of pods will be increased to remediate the issue of
     carts-primary-7c96d87df9-78fh2    2/2     Running   0          5m
     ```
 
-1. To get an overview of the actions that got triggered by the response time SLO violation, you can use the Keptn's bridge. You can access it by a port-forward from your local machine to the Kubernetes cluster:
+1. To get an overview of the actions that got triggered by the response time SLO violation, you can use the Keptn's Bridge. You can access it by a port-forward from your local machine to the Kubernetes cluster:
 
     ```console 
     kubectl port-forward svc/bridge -n keptn 9000:8080
@@ -156,7 +156,7 @@ In this tutorial, the number of pods will be increased to remediate the issue of
     
     {{< popup_image
     link="./assets/bridge_remediation.png"
-    caption="Keptn's bridge">}}
+    caption="Keptn's Bridge">}}
     
 1. Furthermore, you can use Prometheus to double-check the response time:
 


### PR DESCRIPTION
I've fixed the writing of *Keptn's Bridge* for 0.6.0 and 0.5.0.