### PR TITLE
Provide instructions for Minikube support in Quickstart

### DIFF
--- a/content/docs/quickstart/_index.md
+++ b/content/docs/quickstart/_index.md
@@ -13,6 +13,7 @@ weight: 1
 * [Preparing Azure Kubernetes Engine (AKS)](/docs/quickstart/setup_platform/setup_aks)
 * [Preparing Amazon Elastic Kubernetes Service (EKS)](/docs/quickstart/setup_platform/setup_eks)
 * [Preparing Google Kubernetes Engine (GKE)](/docs/quickstart/setup_platform/setup_gke)
+* [Preparing Minikube](/docs/quickstart/setup_platform/setup_minikube)
 * [Preparing OpenShift](/docs/quickstart/setup_platform/setup_openshift)
 * [Preparing Pivotal Container Service (PKS)](/docs/quickstart/setup_platform/setup_pks)
 
@@ -45,6 +46,7 @@ Depending on the platform, Keptn install will prompt you different information n
 ```console
 keptn install --platform=[aks|eks|gke|openshift|pks|kubernetes]
 ```
+**Note:** For a Minikube setup, use option `--platform=kubernetes`.
 
 After a successful installation, you can verify that Keptn is working by executing
 

--- a/content/docs/quickstart/setup_platform/setup_eks/index.md
+++ b/content/docs/quickstart/setup_platform/setup_eks/index.md
@@ -1,7 +1,7 @@
 ---
 title: Setup EKS
 description: How to setup an EKS cluster to be used for Keptn.
-weight: 21
+weight: 22
 keywords: setup
 ---
 

--- a/content/docs/quickstart/setup_platform/setup_gke/index.md
+++ b/content/docs/quickstart/setup_platform/setup_gke/index.md
@@ -1,7 +1,7 @@
 ---
 title: Setup GKE
 description: How to setup a GKE cluster to be used for Keptn.
-weight: 22
+weight: 23
 keywords: setup
 ---
 

--- a/content/docs/quickstart/setup_platform/setup_minikube/index.md
+++ b/content/docs/quickstart/setup_platform/setup_minikube/index.md
@@ -1,0 +1,29 @@
+---
+title: Setup Minikube
+description: How to setup a Minikube cluster to be used for Keptn.
+weight: 24
+keywords: setup
+---
+
+## 1. Install local tools
+  - [minikube 1.2](https://github.com/kubernetes/minikube/releases/tag/v1.2.0) (newer versions do not work).
+
+## 2. Create Minikube VM
+
+* Setup a Minikube VM with at least 6 CPU cores and 12 GB memory using:
+
+```console
+minikube stop # optional
+minikube delete # optional
+minikube start --cpus 6 --memory 12200
+``` 
+
+* Start the Minikube LoadBalancer service in a second terminal by executing:
+
+```console
+minikube tunnel 
+``` 
+
+## 3. Continue with Keptn installation
+
+Now that the Minikube VM is set up, [continue with the Keptn installation](../../#2-install-keptn).

--- a/content/docs/quickstart/setup_platform/setup_openshift/index.md
+++ b/content/docs/quickstart/setup_platform/setup_openshift/index.md
@@ -1,7 +1,7 @@
 ---
 title: Setup OpenShift
 description: How to setup an OpenShift cluster to be used for Keptn.
-weight: 22
+weight: 25
 keywords: setup
 ---
 
@@ -12,48 +12,48 @@ keywords: setup
 
 ## 2. On the OpenShift master node, execute the following steps:
 
-    - Set up the required permissions for your user:
+- Set up the required permissions for your user:
 
-      ```
-      oc adm policy --as system:admin add-cluster-role-to-user cluster-admin <OPENSHIFT_USER_NAME>
-      ```
+```
+oc adm policy --as system:admin add-cluster-role-to-user cluster-admin <OPENSHIFT_USER_NAME>
+```
 
-    - Set up the required permissions for the installer pod:
+- Set up the required permissions for the installer pod:
 
-      ```
-      oc adm policy  add-cluster-role-to-user cluster-admin system:serviceaccount:default:default
-      oc adm policy  add-cluster-role-to-user cluster-admin system:serviceaccount:kube-system:default
-      ```
+```
+oc adm policy  add-cluster-role-to-user cluster-admin system:serviceaccount:default:default
+oc adm policy  add-cluster-role-to-user cluster-admin system:serviceaccount:kube-system:default
+```
 
-    - Enable admission WebHooks on your OpenShift master node:
+- Enable admission WebHooks on your OpenShift master node:
 
-      ```
-      sudo -i
-      cp -n /etc/origin/master/master-config.yaml /etc/origin/master/master-config.yaml.backup
-      oc ex config patch /etc/origin/master/master-config.yaml --type=merge -p '{
-        "admissionConfig": {
-          "pluginConfig": {
-            "ValidatingAdmissionWebhook": {
-              "configuration": {
-                "apiVersion": "apiserver.config.k8s.io/v1alpha1",
-                "kind": "WebhookAdmission",
-                "kubeConfigFile": "/dev/null"
-              }
-            },
-            "MutatingAdmissionWebhook": {
-              "configuration": {
-                "apiVersion": "apiserver.config.k8s.io/v1alpha1",
-                "kind": "WebhookAdmission",
-                "kubeConfigFile": "/dev/null"
-              }
-            }
-          }
+```
+sudo -i
+cp -n /etc/origin/master/master-config.yaml /etc/origin/master/master-config.yaml.backup
+oc ex config patch /etc/origin/master/master-config.yaml --type=merge -p '{
+  "admissionConfig": {
+    "pluginConfig": {
+      "ValidatingAdmissionWebhook": {
+        "configuration": {
+          "apiVersion": "apiserver.config.k8s.io/v1alpha1",
+          "kind": "WebhookAdmission",
+          "kubeConfigFile": "/dev/null"
         }
-      }' >/etc/origin/master/master-config.yaml.patched
-      if [ $? == 0 ]; then
-        mv -f /etc/origin/master/master-config.yaml.patched /etc/origin/master/master-config.yaml
-        /usr/local/bin/master-restart api && /usr/local/bin/master-restart controllers
-      else
-        exit
-      fi
-      ```
+      },
+      "MutatingAdmissionWebhook": {
+        "configuration": {
+          "apiVersion": "apiserver.config.k8s.io/v1alpha1",
+          "kind": "WebhookAdmission",
+          "kubeConfigFile": "/dev/null"
+        }
+      }
+    }
+  }
+}' >/etc/origin/master/master-config.yaml.patched
+if [ $? == 0 ]; then
+  mv -f /etc/origin/master/master-config.yaml.patched /etc/origin/master/master-config.yaml
+  /usr/local/bin/master-restart api && /usr/local/bin/master-restart controllers
+else
+  exit
+fi
+```

--- a/content/docs/quickstart/setup_platform/setup_pks/index.md
+++ b/content/docs/quickstart/setup_platform/setup_pks/index.md
@@ -1,7 +1,7 @@
 ---
 title: Setup PKS
-description: How to setup a PKS cluster to be used for keptn.
-weight: 23
+description: How to setup a PKS cluster to be used for Keptn.
+weight: 26
 keywords: setup
 ---
 


### PR DESCRIPTION
Minikube 1.2 support was missing in the quickstart section. 