### PR TITLE
Added K3s to installation instructions

### DIFF
--- a/content/docs/develop/operate/install/index.md
+++ b/content/docs/develop/operate/install/index.md
@@ -167,6 +167,31 @@ If you [sign up for a Google Cloud account](https://console.cloud.google.com/get
 </p>
 </details>
 
+<details><summary>K3s</summary>
+<p>
+
+**Note**: Please refer to the [official homepage of K3s](https://k3s.io) for detailed installation instructions. Within 
+ this page we only provide a very short guide on how we run Keptn on K3s.
+ 
+1. Download, install [K3s](https://k3s.io/) (tested with [versions 1.16 to 1.18](../k8s_support)) and run K3s using the following command:
+   ```console
+   curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.18.3+k3s1 K3S_KUBECONFIG_MODE="644" sh -s - --no-deploy=traefik
+   ```
+   This installs version `v1.18.3+k3s1` (please refer to the [K3s GitHub releases page](https://github.com/rancher/k3s/releases) for newer releases), sets file permissions `644` on `/etc/rancher/k3s/k3s.yaml` and disables `traefik` as an ingress controller.
+
+1. Export the Kubernetes profile using
+   ```console
+   export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+   ```
+   
+1. Verify that the connection to the cluster works
+   ```console
+   kubectl get nodes   
+   ```
+
+</p>
+</details>
+
 <details><summary>Minikube</summary>
 <p>
 
@@ -243,6 +268,15 @@ keptn install --platform=openshift
 
 ```console
 keptn install --platform=pks
+```
+
+- K3s:
+
+    **Note**: If the Keptn installer is having trouble getting an IP address, try to install with `--gateway=NodePort`.
+
+
+```console
+keptn install --platform=kubernetes
 ```
 
 - Minikube:


### PR DESCRIPTION
This PR adds K3s to the installation instructions for the current develop branch.

I also simplified the quickstart guide to avoid unnecessary redundancy. Quickstart now focuses on GKE and K3s as the primary options.

Preview quickstart: https://deploy-preview-559--keptn.netlify.app/docs/develop/quickstart/
Preview Install: https://deploy-preview-559--keptn.netlify.app/docs/develop/operate/install/