### PR TITLE
Updated keywords to use `See also` feature in pages

### DIFF
--- a/content/docs/0.7.x/automated_operations/action-provider/index.md
+++ b/content/docs/0.7.x/automated_operations/action-provider/index.md
@@ -3,6 +3,7 @@ title: Action-Provider
 description: Add an action-provider to execte custom remediation actions.
 weight: 5
 icon: setup
+keywords: [0.7.x-automated-operations]
 ---
 
 Depending on the action that should be executed in course of a remediation (or operational) workflow, a corresponding action-provider must be deployed. This action-provider receives a Keptn event, performs its action, and notifies Keptn about the execution. 

--- a/content/docs/0.7.x/automated_operations/remediation/index.md
+++ b/content/docs/0.7.x/automated_operations/remediation/index.md
@@ -3,6 +3,7 @@ title: Remediation Config
 description: Configure a remediation and add it to your service.
 weight: 1
 icon: setup
+keywords: [0.7.x-automated-operations]
 ---
 
 The remediation config describes a remediation workflow in a declarative manner. Hence, it only defines what needs to be done and leaves all the details to other components. 

--- a/content/docs/0.7.x/continuous_delivery/deployment_helm/index.md
+++ b/content/docs/0.7.x/continuous_delivery/deployment_helm/index.md
@@ -2,6 +2,7 @@
 title: Deployment with Helm
 description: Details about Keptn using Helm for deployment.
 weight: 10
+keywords: [0.7.x-cd]
 ---
 
 Keptn uses [Helm v3](https://helm.sh/) for deploying onboarded services to a Kubernetes cluster. This is currently implemented in the [helm-service](https://github.com/keptn/keptn/tree/0.6.1/helm-service). The helm-service supports two deployment strategies explained below:

--- a/content/docs/0.7.x/continuous_delivery/expose_services/index.md
+++ b/content/docs/0.7.x/continuous_delivery/expose_services/index.md
@@ -2,6 +2,7 @@
 title: Expose deployed services
 description: Configure Istio and create a ConfigMap to expose services deployed by Keptn. 
 weight: 1
+keywords: [0.7.x-cd]
 ---
 
 To be able to access the services you will deploy by Keptn, Istio has to be installed. This means that the `istio-ingressgateway` service should already be available in the `istio-system` namespace and a `public-gateway` need to be created as explained below. Besides, a ConfigMap must be edited that tells Keptn how the gateway is configured. 

--- a/content/docs/0.7.x/continuous_delivery/multi_stage/index.md
+++ b/content/docs/0.7.x/continuous_delivery/multi_stage/index.md
@@ -2,6 +2,7 @@
 title: Multi-stage delivery workflow
 description: Customize your delivery workflow and staging process.
 weight: 1
+keywords: [0.7.x-cd]
 ---
 
 The definition of a multi-stage delivery workflow manifests in a so-called **shipyard**. It can hold multiple stages with dedicated and opinionated delivery tasks to execute. Following this declarative approach, there is no need to write imperative pipeline code. Keptn takes the shipyard file and creates a multi-stage delivery workflow.

--- a/content/docs/0.7.x/integrations/action_provider/index.md
+++ b/content/docs/0.7.x/integrations/action_provider/index.md
@@ -2,6 +2,7 @@
 title: Custom Action-Provider
 description: Implement an action-provider that executes a remedation action as response to a problem.
 weight: 10
+keywords: [0.7.x-integration]
 ---
 
 An *action-provider* is an implementation of a [*Keptn-service*](../custom_integration/#keptn-service) with a dedicated purpose. This type of service is responsible for executing a remediation action and therefore might even use another tool.  

--- a/content/docs/0.7.x/integrations/custom_integration/index.md
+++ b/content/docs/0.7.x/integrations/custom_integration/index.md
@@ -2,6 +2,7 @@
 title: Write a Keptn-service
 description: Implement your Keptn-service that listens to Keptn events and extends your Keptn with certain functionality.
 weight: 1
+keywords: [0.7.x-integration]
 ---
 
 Here you learn how to add additional functionality to your Keptn installation with a custom [*Keptn-service*](#keptn-service) or [*SLI-provider*](#sli-provider). While a *Keptn-service* enriches a continuous delivery or operational workflow with additional functionality or with an extra tool, a *SLI-provider* is used to query Service-Level Indicators (SLI) from an external source like a monitoring or testing solution.  

--- a/content/docs/0.7.x/integrations/sli_provider/index.md
+++ b/content/docs/0.7.x/integrations/sli_provider/index.md
@@ -2,6 +2,7 @@
 title: Custom SLI-Provider
 description: Implement an SLI-provider that queries an external data source for SLIs.
 weight: 5
+keywords: [0.7.x-integration]
 ---
 
 An *SLI-provider* is an implementation of a [*Keptn-service*](../custom_integration/#keptn-service) with a dedicated purpose. This type of service is responsible for querying an external data source for SLIs that are then used by Keptn to evaluate an SLO. To configure a query for an indicator, Keptn provides the concept of an [SLI configuration](https://github.com/keptn/spec/blob/0.1.4/sre.md#service-level-indicators-sli-configuration).

--- a/content/docs/0.7.x/manage/git_upstream/index.md
+++ b/content/docs/0.7.x/manage/git_upstream/index.md
@@ -2,7 +2,7 @@
 title: Git-based upstream  
 description: Select a Get-based upstream for a project.
 weight: 20
-keywords: [manage]
+keywords: [0.7.x-manage]
 aliases:
   - /docs/0.7.0/manage/git_upstream/
 ---

--- a/content/docs/0.7.x/manage/project/index.md
+++ b/content/docs/0.7.x/manage/project/index.md
@@ -2,7 +2,7 @@
 title: Project with Stages
 description: Create and delete a project in Keptn.
 weight: 20
-keywords: [manage]
+keywords: [0.7.x-manage]
 aliases:
 ---
 

--- a/content/docs/0.7.x/manage/service/index.md
+++ b/content/docs/0.7.x/manage/service/index.md
@@ -2,7 +2,7 @@
 title: Service
 description: Create or onboard your service in Keptn.
 weight: 30
-keywords: [manage]
+keywords: [0.7.x-manage]
 aliases:
 ---
 

--- a/content/docs/0.7.x/monitoring/dynatrace/_index.md
+++ b/content/docs/0.7.x/monitoring/dynatrace/_index.md
@@ -3,7 +3,6 @@ title: Dynatrace
 description: Setup Dynatrace monitoring
 weight: 1
 icon: setup
-keywords: setup
 ---
 
 To evaluate the quality gates and allow self-healing in production, we have to set up monitoring to get the needed data.

--- a/content/docs/0.7.x/monitoring/dynatrace/best_practices/index.md
+++ b/content/docs/0.7.x/monitoring/dynatrace/best_practices/index.md
@@ -3,7 +3,6 @@ title: Best Practices
 description: Best practices for Dynatrace monitoring
 weight: 3
 icon: setup
-keywords: setup
 ---
 
 ## Set DT_CUSTOM_PROP before onboarding a service

--- a/content/docs/0.7.x/monitoring/dynatrace/install/index.md
+++ b/content/docs/0.7.x/monitoring/dynatrace/install/index.md
@@ -3,7 +3,6 @@ title: Install
 description: Setup Dynatrace monitoring and Keptn integration
 weight: 1
 icon: setup
-keywords: setup
 ---
 
 ## Deploy OneAgent Operator on Kubernetes

--- a/content/docs/0.7.x/monitoring/dynatrace/sli_provider/index.md
+++ b/content/docs/0.7.x/monitoring/dynatrace/sli_provider/index.md
@@ -3,7 +3,6 @@ title: SLI-Provider
 description: Setup SLI-Provider
 weight: 4
 icon: setup
-keywords: setup
 ---
 
 ## Setup Dynatrace SLI-provider

--- a/content/docs/0.7.x/monitoring/dynatrace/uninstall/index.md
+++ b/content/docs/0.7.x/monitoring/dynatrace/uninstall/index.md
@@ -3,7 +3,6 @@ title: Uninstall
 description: Uninstall
 weight: 2
 icon: setup
-keywords: setup
 ---
 
 ## Uninstall Dynatrace

--- a/content/docs/0.7.x/monitoring/prometheus/_index.md
+++ b/content/docs/0.7.x/monitoring/prometheus/_index.md
@@ -3,7 +3,6 @@ title: Prometheus
 description: Setup Prometheus monitoring
 weight: 2
 icon: setup
-keywords: setup
 ---
 
 To evaluate the quality gates and allow self-healing in production, we have to set up monitoring to get the needed data.

--- a/content/docs/0.7.x/monitoring/prometheus/install/index.md
+++ b/content/docs/0.7.x/monitoring/prometheus/install/index.md
@@ -3,7 +3,6 @@ title: Install
 description: Setup Prometheus monitoring
 weight: 1
 icon: setup
-keywords: setup
 ---
 
 In order to evaluate the quality gates and allow self-healing in production, we have to set up monitoring to get the needed data.

--- a/content/docs/0.7.x/monitoring/prometheus/sli-provider/index.md
+++ b/content/docs/0.7.x/monitoring/prometheus/sli-provider/index.md
@@ -3,7 +3,6 @@ title: SLI-Provider
 description: Install SLI-Provider
 weight: 1
 icon: setup
-keywords: setup
 ---
 
 ## Setup Prometheus SLI-provider 

--- a/content/docs/0.7.x/operate/api_token/index.md
+++ b/content/docs/0.7.x/operate/api_token/index.md
@@ -2,7 +2,6 @@
 title: API Token
 description: Manage the API token of a Keptn installation.
 weight: 35
-keywords: [api, api-token]
 ---
 
 In this section, the management of the API token of a Keptn installation is explained.

--- a/content/docs/0.7.x/operate/install/index.md
+++ b/content/docs/0.7.x/operate/install/index.md
@@ -2,7 +2,7 @@
 title: Install CLI and Keptn
 description: Install Keptn on your Kubernetes cluster and expose it.
 weight: 1
-keywords: setup
+keywords: [0.7.x-operate]
 aliases:
   - /docs/0.7.0/operate/install/
 ---

--- a/content/docs/0.7.x/operate/k8s_support/index.md
+++ b/content/docs/0.7.x/operate/k8s_support/index.md
@@ -1,8 +1,8 @@
 ---
 title: Kubernetes Support
-description: Keptn and Kubernetes compatibility overview
+description: Keptn and Kubernetes compatibility overview.
 weight: 30
-keywords: setup
+keywords: [0.7.x-operate]
 ---
 
 This document describes the maximum version skew supported between Keptn and Kubernetes.

--- a/content/docs/0.7.x/operate/uninstall/index.md
+++ b/content/docs/0.7.x/operate/uninstall/index.md
@@ -2,7 +2,7 @@
 title: Uninstall Keptn
 description: Uninstall Keptn from a Kubernetes cluster.
 weight: 10
-keywords: setup
+keywords: [0.7.x-operate]
 ---
 
 ## Prerequisites

--- a/content/docs/0.7.x/operate/upgrade/index.md
+++ b/content/docs/0.7.x/operate/upgrade/index.md
@@ -2,7 +2,6 @@
 title: Upgrade Keptn
 description: Upgrade your Keptn to 0.7
 weight: 5
-keywords: upgrade
 aliases:
   - /docs/0.7.0/operate/upgrade/
 ---

--- a/content/docs/0.7.x/quality_gates/sli-provider/index.md
+++ b/content/docs/0.7.x/quality_gates/sli-provider/index.md
@@ -2,6 +2,7 @@
 title: SLI-Provider
 description: Add an SLI-Provider to Keptn for querying provider-specific SLIs.
 weight: 3
+keywords: [0.7.x-quality_gates]
 ---
 
 Depending on the monitoring solution you have in place and the SLIs you have configured for your services, you need to deploy the corresponding SLI-provider. In Keptn 0.7, this can be either *Dynatrace* or *Prometheus*. 

--- a/content/docs/0.7.x/quality_gates/sli/index.md
+++ b/content/docs/0.7.x/quality_gates/sli/index.md
@@ -2,6 +2,7 @@
 title: Service-Level Indicators (SLI)
 description: Configure Service-Level Indicators (SLIs) for your service.
 weight: 2
+keywords: [0.7.x-quality_gates]
 ---
 
 A Service-Level Indicator (SLI) is a defined quantitative measure of some aspects of the service level. The query for an SLI is provider/tool-dependent. This is the reason why each SLI-provider relies on an individual SLI configuration. This SLI configuration lists those SLIs that are supported by the SLI-provider by their name and query whereas the query is provider specific. 

--- a/content/docs/0.7.x/quality_gates/slo/index.md
+++ b/content/docs/0.7.x/quality_gates/slo/index.md
@@ -2,6 +2,7 @@
 title: Service-Level Objectives (SLO)
 description: Configure and add Service-Level Objectives (SLO) to your service.
 weight: 1
+keywords: [0.7.x-quality_gates]
 ---
 
 The Service-Level Objective (SLO) configuration specifies a target value or range of values for a service level that is measured by [Service-Level Indicators (SLI)](../sli). 

--- a/content/docs/0.7.x/reference/api/index.md
+++ b/content/docs/0.7.x/reference/api/index.md
@@ -2,7 +2,6 @@
 title: Keptn API
 description: Explains how to connect the Keptn API and which commands are available.
 weight: 11
-keywords: [api, setup]
 ---
 
 In this section, the functionality and commands of the Keptn REST API are described.

--- a/content/docs/0.7.x/reference/bridge/_index.md
+++ b/content/docs/0.7.x/reference/bridge/_index.md
@@ -2,7 +2,6 @@
 title: Keptn Bridge
 description: The user interface of Keptn that presents all projects and services managed by Keptn. It is automatically installed with your Keptn deployment.
 weight: 21
-keywords: [bridge]
 ---
 
 ## Views in Keptn Bridge

--- a/content/docs/0.7.x/reference/bridge/basic_authentication/index.md
+++ b/content/docs/0.7.x/reference/bridge/basic_authentication/index.md
@@ -2,7 +2,7 @@
 title: Basic Authentication
 description: Enable/Disable basic authentication
 weight: 21
-keywords: [bridge]
+keywords: [0.7.x-bridge]
 ---
 
 The Keptn Bridge has a basic authentication feature, which can be controlled by setting the following two environment variables in the deployment of the bridge::

--- a/content/docs/0.7.x/reference/bridge/deep_linking/index.md
+++ b/content/docs/0.7.x/reference/bridge/deep_linking/index.md
@@ -2,7 +2,7 @@
 title: Deep Linking
 description: Deep links into Bridge for better integration into DevOps tools
 weight: 21
-keywords: [bridge]
+keywords: [0.7.x-bridge]
 ---
 
 For integration of the Keptn Bridge into DevOps tools, a list of deep links is provided. 

--- a/content/docs/0.7.x/reference/bridge/delivery_assistent/index.md
+++ b/content/docs/0.7.x/reference/bridge/delivery_assistent/index.md
@@ -2,7 +2,7 @@
 title: Delivery Assistent
 description: Approval of deployment for manual approval strategy
 weight: 50
-keywords: [bridge]
+keywords: [0.7.x-bridge]
 ---
 
 If you configured `manual` approval for your [multi-stage delivery workflow](../../../continuous_delivery/multi_stage/#approval-strategy), the Keptn Bridge allows you to send an `approval.finished` event to Keptn to confirm/decline an open approval.

--- a/content/docs/0.7.x/reference/cli/_index.md
+++ b/content/docs/0.7.x/reference/cli/_index.md
@@ -3,7 +3,6 @@ title: Keptn CLI
 description: Explains how to download and install the Keptn CLI as well as which commands are available.
 weight: 30
 icon: help
-keywords: [cli, setup]
 ---
 
 In this section, the functionality and commands of the Keptn CLI are described. The Keptn CLI allows installing, configuring, and

--- a/content/docs/0.7.x/reference/cli/commands/_index.md
+++ b/content/docs/0.7.x/reference/cli/commands/_index.md
@@ -3,5 +3,4 @@ title: Commands
 description: Auto-generated documentation of keptn CLI
 weight: 30
 icon: reference
-keywords: [cli]
 ---

--- a/content/docs/0.7.x/reference/version_check/index.md
+++ b/content/docs/0.7.x/reference/version_check/index.md
@@ -2,7 +2,6 @@
 title: Daily Version Check
 description: Enable/Disable daily version check feature
 weight: 40
-keywords: [bridge]
 ---
 
 The feature of a daily version check informs a Keptn user in the Keptn Bridge about:

--- a/content/docs/0.7.x/troubleshooting/index.md
+++ b/content/docs/0.7.x/troubleshooting/index.md
@@ -3,7 +3,6 @@ title: Troubleshooting
 description: Find tips and tricks to deal with troubles that may occur when using Keptn. 
 weight: 100
 icon: help
-keywords: [troubleshooting]
 ---
 
 In this section, instructions have been summarized that help to troubleshoot known issues that may occur when using Keptn.

--- a/layouts/partials/primary-bottom.html
+++ b/layouts/partials/primary-bottom.html
@@ -1,7 +1,24 @@
 {{ $toc := partial "toc.html" (dict "page" .) }}
 {{ $needTOC := .Scratch.Get "needTOC" }}
 
+        {{ if .Scratch.Get "seeAlso" }}
+            {{ $related := .Site.RegularPages.Related . | first 6 }}
+            {{ with $related }}
+                <nav id="see-also">
+                    <h2>See also</h2>
 
+                    <div class="see-also">
+                        <ul>
+                        {{ range . }}
+                            <div class="entry">
+                                <li class="link"><a data-skipendnotes="true" href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>: {{ .Description }}</li>
+                            </div>
+                        {{ end }}
+                        </ul>
+                    </div>
+            </nav>
+        {{ end }}
+        {{ end }}
         </main>
 
         {{ if or .NextInSection .PrevInSection }}


### PR DESCRIPTION
This PR solves the problem that the "See also" section in each page did not work. 
Now, pages that share the same keywords are listed in this section. 

![image](https://user-images.githubusercontent.com/729071/88808343-0f0bbc80-d1b3-11ea-92a3-90e1d0badfcd.png)
