### PR TITLE
Use create instead of replace when creating Secret or ConfigMap

### DIFF
--- a/content/docs/0.7.x/continuous_delivery/expose_services/index.md
+++ b/content/docs/0.7.x/continuous_delivery/expose_services/index.md
@@ -64,7 +64,7 @@ kubectl apply -f gateway-manifest.yaml
       **Note:** In the above example, `xip.io` is used as wildcard DNS for the IP address.
 
     ```console
-    kubectl create configmap -n keptn ingress-config --from-literal=ingress_hostname_suffix=${INGRESS_HOSTNAME} --from-literal=ingress_port=${INGRESS_PORT} --from-literal=ingress_protocol=${INGRESS_PROTOCOL} --from-literal=istio_gateway=${ISTIO_GATEWAY} -oyaml --dry-run | kubectl replace -f -
+    kubectl create configmap -n keptn ingress-config --from-literal=ingress_hostname_suffix=${INGRESS_HOSTNAME} --from-literal=ingress_port=${INGRESS_PORT} --from-literal=ingress_protocol=${INGRESS_PROTOCOL} --from-literal=istio_gateway=${ISTIO_GATEWAY} -oyaml --dry-run | kubectl create -f -
     ```
 
 * If you have already set up a domain that points to your Istio ingress, you can use it for the `INGRESS_HOSTNAME_SUFFIX`. In this case, use the following command to create the `ingress-config` ConfigMap in the `keptn` namespace:
@@ -77,7 +77,7 @@ kubectl apply -f gateway-manifest.yaml
     ```
     
     ```console
-    kubectl create configmap -n keptn ingress-config --from-literal=ingress_hostname_suffix=${INGRESS_HOSTNAME} --from-literal=ingress_port=${INGRESS_PORT} --from-literal=ingress_protocol=${INGRESS_PROTOCOL} --from-literal=istio_gateway=${ISTIO_GATEWAY} -oyaml --dry-run | kubectl replace -f -
+    kubectl create configmap -n keptn ingress-config --from-literal=ingress_hostname_suffix=${INGRESS_HOSTNAME} --from-literal=ingress_port=${INGRESS_PORT} --from-literal=ingress_protocol=${INGRESS_PROTOCOL} --from-literal=istio_gateway=${ISTIO_GATEWAY} -oyaml --dry-run | kubectl create -f -
     ```
 
 * After creating the ConfigMap, restart the `helm-service`:

--- a/content/docs/0.7.x/monitoring/dynatrace/install/index.md
+++ b/content/docs/0.7.x/monitoring/dynatrace/install/index.md
@@ -83,7 +83,7 @@ Create a secret containing the credentials for the *Dynatrace tenant* and *Keptn
 * Create a secret with the credentials by executing the following command:
 
     ```console
-    kubectl -n keptn create secret generic dynatrace --from-literal="DT_API_TOKEN=$DT_API_TOKEN" --from-literal="DT_TENANT=$DT_TENANT" --from-literal="KEPTN_API_URL=$KEPTN_API_URL" --from-literal="KEPTN_API_TOKEN=$KEPTN_API_TOKEN" -oyaml --dry-run | kubectl replace -f -
+    kubectl -n keptn create secret generic dynatrace --from-literal="DT_API_TOKEN=$DT_API_TOKEN" --from-literal="DT_TENANT=$DT_TENANT" --from-literal="KEPTN_API_URL=$KEPTN_API_URL" --from-literal="KEPTN_API_TOKEN=$KEPTN_API_TOKEN" -oyaml --dry-run | kubectl create -f -
     ```
 
 ### 2. Deploy the Dynatrace Keptn integration

--- a/content/docs/0.8.x/continuous_delivery/expose_services/index.md
+++ b/content/docs/0.8.x/continuous_delivery/expose_services/index.md
@@ -64,7 +64,7 @@ kubectl apply -f gateway-manifest.yaml
       **Note:** In the above example, `xip.io` is used as wildcard DNS for the IP address.
 
     ```console
-    kubectl create configmap -n keptn ingress-config --from-literal=ingress_hostname_suffix=${INGRESS_HOSTNAME} --from-literal=ingress_port=${INGRESS_PORT} --from-literal=ingress_protocol=${INGRESS_PROTOCOL} --from-literal=istio_gateway=${ISTIO_GATEWAY} -oyaml --dry-run | kubectl replace -f -
+    kubectl create configmap -n keptn ingress-config --from-literal=ingress_hostname_suffix=${INGRESS_HOSTNAME} --from-literal=ingress_port=${INGRESS_PORT} --from-literal=ingress_protocol=${INGRESS_PROTOCOL} --from-literal=istio_gateway=${ISTIO_GATEWAY} -oyaml --dry-run | kubectl create -f -
     ```
 
 * If you have already set up a domain that points to your Istio ingress, you can use it for the `INGRESS_HOSTNAME_SUFFIX`. In this case, use the following command to create the `ingress-config` ConfigMap in the `keptn` namespace:
@@ -77,7 +77,7 @@ kubectl apply -f gateway-manifest.yaml
     ```
     
     ```console
-    kubectl create configmap -n keptn ingress-config --from-literal=ingress_hostname_suffix=${INGRESS_HOSTNAME} --from-literal=ingress_port=${INGRESS_PORT} --from-literal=ingress_protocol=${INGRESS_PROTOCOL} --from-literal=istio_gateway=${ISTIO_GATEWAY} -oyaml --dry-run | kubectl replace -f -
+    kubectl create configmap -n keptn ingress-config --from-literal=ingress_hostname_suffix=${INGRESS_HOSTNAME} --from-literal=ingress_port=${INGRESS_PORT} --from-literal=ingress_protocol=${INGRESS_PROTOCOL} --from-literal=istio_gateway=${ISTIO_GATEWAY} -oyaml --dry-run | kubectl create -f -
     ```
 
 * After creating the ConfigMap, restart the `helm-service`:

--- a/content/docs/0.8.x/monitoring/dynatrace/install/index.md
+++ b/content/docs/0.8.x/monitoring/dynatrace/install/index.md
@@ -83,7 +83,7 @@ Create a secret containing the credentials for the *Dynatrace tenant* and *Keptn
 * Create a secret with the credentials by executing the following command:
 
     ```console
-    kubectl -n keptn create secret generic dynatrace --from-literal="DT_API_TOKEN=$DT_API_TOKEN" --from-literal="DT_TENANT=$DT_TENANT" --from-literal="KEPTN_API_URL=$KEPTN_API_URL" --from-literal="KEPTN_API_TOKEN=$KEPTN_API_TOKEN" -oyaml --dry-run | kubectl replace -f -
+    kubectl -n keptn create secret generic dynatrace --from-literal="DT_API_TOKEN=$DT_API_TOKEN" --from-literal="DT_TENANT=$DT_TENANT" --from-literal="KEPTN_API_URL=$KEPTN_API_URL" --from-literal="KEPTN_API_TOKEN=$KEPTN_API_TOKEN" -oyaml --dry-run | kubectl create -f -
     ```
 
 ### 2. Deploy the Dynatrace Keptn integration


### PR DESCRIPTION
Based on user feedback, the command: 
`kubectl create configmap -n keptn ingress-config --from-literal=ingress_hostname_suffix=${INGRESS_HOSTNAME} --from-literal=ingress_port=${INGRESS_PORT} --from-literal=ingress_protocol=${INGRESS_PROTOCOL} --from-literal=istio_gateway=${ISTIO_GATEWAY} -oyaml --dry-run | kubectl replace -f -` does not work on a fresh cluster, since the configmap is not available. 

I fixed it by changing it to `create` instead of `replace`. 