### PR TITLE
#2990 #2989 Keptn Onboard Service updates

### DIFF
--- a/content/docs/0.8.x/continuous_delivery/deployment_helm/index.md
+++ b/content/docs/0.8.x/continuous_delivery/deployment_helm/index.md
@@ -5,16 +5,16 @@ weight: 10
 keywords: [0.8.x-cd]
 ---
 
-Keptn uses [Helm v3](https://helm.sh/) for deploying onboarded services to a Kubernetes cluster. This is currently implemented in the [helm-service](https://github.com/keptn/keptn/tree/0.7.3/helm-service). The helm-service supports two deployment strategies explained below:
+Keptn uses [Helm v3](https://helm.sh/) for deploying onboarded services to a Kubernetes cluster. This is currently implemented in the [helm-service](https://github.com/keptn/keptn/tree/0.8.0/helm-service). The helm-service supports two deployment strategies explained below:
 
 * **Direct deployments**
 * **Blue-green deployments**
 
-The explanation is based on the provided Helm Chart for the carts microservice, see [Charts](https://github.com/keptn/examples/tree/0.7.3/onboarding-carts/carts) for details.
+The explanation is based on the provided Helm Chart for the carts microservice, see [Charts](https://github.com/keptn/examples/tree/0.8.0/onboarding-carts/carts) for details.
 
 ## Direct deployments
 
-If the deployment strategy of a stage in the [shipyard](https://github.com/keptn/examples/blob/0.7.3/onboarding-carts/shipyard.yaml) is configured as `deployment_strategy: direct`, Helm deploys a 
+If the deployment strategy of a stage in the [shipyard](https://github.com/keptn/examples/blob/0.8.0/onboarding-carts/shipyard.yaml) is configured as `deployment_strategy: direct`, Helm deploys a 
  release called `sockshop-dev-carts` as `carts` in namespace `sockshop-dev`.
  
 ```console
@@ -28,12 +28,12 @@ carts   1/1     1            1           56m   carts        docker.io/keptnexamp
 
 When sending a new-artifact, we are updating the values.yaml file in the Helm Charts with the respective image name.
 
-* [chart/values.yaml](https://github.com/keptn/examples/blob/0.7.3/onboarding-carts/carts/values.yaml#L1)
-* [chart/templates/deployment.yaml](https://github.com/keptn/examples/blob/0.7.3/onboarding-carts/carts/templates/deployment.yaml#L22)
+* [chart/values.yaml](https://github.com/keptn/examples/blob/0.8.0/onboarding-carts/carts/values.yaml#L1)
+* [chart/templates/deployment.yaml](https://github.com/keptn/examples/blob/0.8.0/onboarding-carts/carts/templates/deployment.yaml#L22)
 
 ## Blue-green deployments
 
-If the deployment strategy of a stage in the [shipyard](https://github.com/keptn/examples/blob/0.7.3/onboarding-carts/shipyard.yaml) is configured as `deployment_strategy: blue_green_service`, Helm creates two
+If the deployment strategy of a stage in the [shipyard](https://github.com/keptn/examples/blob/0.8.0/onboarding-carts/shipyard.yaml) is configured as `deployment_strategy: blue_green_service`, Helm creates two
  deployments within the Kubernetes cluster: (1) the primary and (2) the canary deployment. This can be inspected using the
  following command:
 
@@ -79,11 +79,10 @@ carts           0/0     0            0            1d   carts        docker.io/ke
 
 When executing [keptn delete project](../../reference/cli/commands/keptn_delete_project/), Keptn does **not** clean up existing deployments nor Helm releases. To do so, delete all relevant namespaces:
 
-* For each stage defined the shipyard file, execute `kubectl delete namespace PROJECTNAME-STAGENAME`, e.g.:
+* For each stage defined stage within the shipyard file of the project, execute `kubectl delete namespace <PROJECTNAME>-<STAGENAME>`, e.g. for `sockshop` with stages `dev`, `staging` and `production`:
 
   ```console
   kubectl delete namespace sockshop-dev
   kubectl delete namespace sockshop-staging
   kubectl delete namespace sockshop-production
   ```
-**Note:** This will also delete the corresponding Helm releases, which are stored as Kubernetes secrets in the namespaces.

--- a/content/docs/0.8.x/manage/service/index.md
+++ b/content/docs/0.8.x/manage/service/index.md
@@ -84,3 +84,10 @@ keptn onboard service SERVICENAME --project=PROJECTNAME --chart=FILEPATH
 ```console
 keptn onboard service SERVICENAME --project=PROJECTNAME --chart=HELM_CHART.tgz
 ```
+
+* Optional: In the case of using an archived Helm chart, you can achieve the same using [keptn create service](../../reference/cli/commands/keptn_create_service) and [keptn add-resource ... --all-stages](../../reference/cli/commands/keptn_add-resource), e.g.:
+
+```console
+keptn create service SERVICENAME --project=PROJECTNAME
+keptn add-resource --project=PROJECTNAME --service=SERVICENAME --all-stages --resource=HELM_CHART.tgz --resourceUri=helm/SERVICENAME.tgz
+```


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

With this PR I am updating the docs according to the following two issues
* https://github.com/keptn/keptn/issues/2989
* https://github.com/keptn/keptn/issues/2990

The main changes here are the fact that onboard service now works a little different (in the background), and that we have added '--all-stages` to the `keptn add-resource` command.

Previews:
* https://deploy-preview-752--keptn.netlify.app/docs/0.8.x/continuous_delivery/deployment_helm/
* https://deploy-preview-752--keptn.netlify.app/docs/0.8.x/manage/service/
