### PR TITLE
Update istio ingress for api-service

### DIFF
--- a/content/docs/0.8.x/operate/install/index.md
+++ b/content/docs/0.8.x/operate/install/index.md
@@ -361,7 +361,7 @@ Depending on whether you would like to install the execution plane for continuou
 
     Commonly used Ingress-Controller are e.g. Istio and NGINX:
 
-    <details><summary>**Istio**</summary>
+    <details><summary>**Istio 1.8+**</summary>
     <p>
 
     * Istio provides an Ingres Controller. To install Istio, please refer to the [official documentation](https://istio.io/latest/docs/setup/install/).
@@ -387,9 +387,13 @@ Depending on whether you would like to install the execution plane for continuou
       - host: <IP-ADDRESS>.nip.io
         http:
           paths:
-          - backend:
-              serviceName: api-gateway-nginx
-              servicePort: 80
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: api-gateway-nginx
+                port:
+                  number: 80
       ```
 
       ```console


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

During setup of 0.8.0-dev I noticed that the istio ingress for api-gateway-nginx is not working anymore with istio 1.8.

As Istio 1.8+ is our current istio target version, I've updated it here accordingly.