### PR TITLE
Replace xip.io with nip.io

### DIFF
--- a/content/docs/0.7.x/continuous_delivery/expose_services/index.md
+++ b/content/docs/0.7.x/continuous_delivery/expose_services/index.md
@@ -55,13 +55,13 @@ kubectl apply -f gateway-manifest.yaml
 * Create the `ingress-config` ConfigMap in the `keptn` namespace:
 
     ```
-    INGRESS_HOSTNAME=<IP_OF_YOUR_INGRESS>.xip.io
+    INGRESS_HOSTNAME=<IP_OF_YOUR_INGRESS>.nip.io
     INGRESS_PORT=<PORT_OF_YOUR_INGRESS> 
     INGRESS_PROTOCOL=<PROTOCOL>                            # "http" or "https"
     ISTIO_GATEWAY=<GATEWAY_NAME>.<NAMESPACE_OF_GATEWAY>  # e.g. public-gateway.istio-system
     ```
 
-      **Note:** In the above example, `xip.io` is used as wildcard DNS for the IP address.
+      **Note:** In the above example, `nip.io` is used as wildcard DNS for the IP address.
 
     ```console
     kubectl create configmap -n keptn ingress-config --from-literal=ingress_hostname_suffix=${INGRESS_HOSTNAME} --from-literal=ingress_port=${INGRESS_PORT} --from-literal=ingress_protocol=${INGRESS_PROTOCOL} --from-literal=istio_gateway=${ISTIO_GATEWAY} -oyaml --dry-run | kubectl replace -f -

--- a/content/docs/0.7.x/troubleshooting/index.md
+++ b/content/docs/0.7.x/troubleshooting/index.md
@@ -194,7 +194,7 @@ keptn status
 ```console
 Starting to authenticate
 Successfully authenticated
-CLI is authenticated against the Keptn cluster http://xx.xx.xx.xx.xip.io/api
+CLI is authenticated against the Keptn cluster http://xx.xx.xx.xx.nip.io/api
 ```
 
 ## NGNIX troubleshooting

--- a/content/docs/0.8.x/continuous_delivery/expose_services/index.md
+++ b/content/docs/0.8.x/continuous_delivery/expose_services/index.md
@@ -55,14 +55,14 @@ kubectl apply -f gateway-manifest.yaml
 * Create the `ingress-config` ConfigMap in the `keptn` namespace:
 
     ```
-    INGRESS_HOSTNAME_SUFFIX=<IP_OF_YOUR_INGRESS>.xip.io
+    INGRESS_HOSTNAME_SUFFIX=<IP_OF_YOUR_INGRESS>.nip.io
     INGRESS_PORT=<PORT_OF_YOUR_INGRESS> 
     INGRESS_PROTOCOL=<PROTOCOL>                            # "http" or "https"
     ISTIO_GATEWAY=<GATEWAY_NAME>.<NAMESPACE_OF_GATEWAY>  # e.g. public-gateway.istio-system
     HOSTNAME_TEMPLATE=<HOSTNAME_TEMPLATE> # optional, default = \${INGRESS_PROTOCOL}://\${service}.\${project}-\${stage}.\${INGRESS_HOSTNAME_SUFFIX}:\${INGRESS_PORT}
     ```
 
-      **Note:** In the above example, `xip.io` is used as wildcard DNS for the IP address.
+      **Note:** In the above example, `nip.io` is used as wildcard DNS for the IP address.
       **Note:** The `HOSTNAME_TEMPLATE` describes how the hostname for the automatically generated `VirtualService` should look like. This value will also be used for the `deploymentURIPublic` property contained in the `deployment.finished` events sent by the helm-service will look like. This URL can then be used by execution plane services that need to access the deployed service (e.g. a testing service like the jmeter-service).
       Within the `HOSTNAME_TEMPLATE`, you can use the variables `INGRESS_HOSTNAME_SUFFIX`, `INGRESS_PORT`, `INGRESS_PROTOCOL`, as well as `project`, `stage` and `service`. Please escape those variables using `\${}` when defining the value for `HOSTNAME_TEMPLATE`, since the resulting string should contain the placeholders of those variables instead of their actual values.
 

--- a/content/docs/0.8.x/troubleshooting/index.md
+++ b/content/docs/0.8.x/troubleshooting/index.md
@@ -194,7 +194,7 @@ keptn status
 ```console
 Starting to authenticate
 Successfully authenticated
-CLI is authenticated against the Keptn cluster http://xx.xx.xx.xx.xip.io/api
+CLI is authenticated against the Keptn cluster http://xx.xx.xx.xx.nip.io/api
 ```
 
 ## NGNIX troubleshooting


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

While going through the setup of helm-service, I noticed that we are still referring to xip.io, which is highly unreliable and causes problems.
This PR replaces occurrences of xip.io with nip.io (for 0.7.x and 0.8.x).