### PR TITLE
Update get.keptn.sh quickstart instructions

### DIFF
--- a/content/docs/0.6.0/reference/cli/_index.md
+++ b/content/docs/0.6.0/reference/cli/_index.md
@@ -18,7 +18,7 @@ This works for Linux and Mac only.
 
 1. This will download the 0.6.2 CLI version from [GitHub](https://github.com/keptn/keptn/releases), unpack it and move it to `/usr/local/bin/keptn`.
 ```console
-curl -sL https://get.keptn.sh | sudo -E bash
+curl -sL https://get.keptn.sh | KEPTN_VERSION=0.6.2 bash
 ```
 
 2. Verify that the installation has worked and that the version is correct by running:

--- a/content/docs/0.7.x/operate/upgrade/index.md
+++ b/content/docs/0.7.x/operate/upgrade/index.md
@@ -18,7 +18,7 @@ aliases:
 
       * The next command will download the 0.7.3 release from [GitHub](https://github.com/keptn/keptn/releases), unpack it, and move it to `/usr/local/bin/keptn`.
 ```console
-curl -sL https://get.keptn.sh | sudo -E bash
+curl -sL https://get.keptn.sh | KEPTN_VERSION=0.7.3 bash
 ```
     
       * Verify that the installation has worked and that the version is correct by running:

--- a/content/docs/0.7.x/reference/cli/_index.md
+++ b/content/docs/0.7.x/reference/cli/_index.md
@@ -17,7 +17,7 @@ This works for Linux and Mac only.
 
 1. This will download the 0.7.3 CLI version from [GitHub](https://github.com/keptn/keptn/releases), unpack it and move it to `/usr/local/bin/keptn`.
 ```console
-curl -sL https://get.keptn.sh | sudo -E bash
+curl -sL https://get.keptn.sh | KEPTN_VERSION=0.7.3 bash
 ```
 
 2. Verify that the installation has worked and that the version is correct by running:

--- a/content/docs/0.8.x/operate/upgrade/index.md
+++ b/content/docs/0.8.x/operate/upgrade/index.md
@@ -20,7 +20,7 @@ Please follow the three steps to succesfully upgrade your Keptn 0.7.3 to 0.8.0
       * The next command will download the 0.8.0 release from [GitHub](https://github.com/keptn/keptn/releases), unpack it, and move it to `/usr/local/bin/keptn`.
 
         ```console
-        curl -sL https://get.keptn.sh | sudo -E bash
+        curl -sL https://get.keptn.sh | bash
         ```
     
       * Verify that the installation has worked and that the version is correct by running:

--- a/content/docs/0.8.x/reference/cli/_index.md
+++ b/content/docs/0.8.x/reference/cli/_index.md
@@ -17,7 +17,7 @@ This works for Linux and Mac only.
 
 1. This will download the 0.7.3 CLI version from [GitHub](https://github.com/keptn/keptn/releases), unpack it and move it to `/usr/local/bin/keptn`.
 ```console
-curl -sL https://get.keptn.sh | sudo -E bash
+curl -sL https://get.keptn.sh | bash
 ```
 
 2. Verify that the installation has worked and that the version is correct by running:


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

This PR updates instructions when downloading the CLI via get.keptn.sh.

* we don't use `sudo -E bash` anymore, `bash` is enough
* old versions of Keptn can still be downloaded, but `KEPTN_VERSION=x.y.z` needs to be specified
 