### PR TITLE
adding kubecon page

### DIFF
--- a/content/community/kubecon-eu-2021/index.md
+++ b/content/community/kubecon-eu-2021/index.md
@@ -1,0 +1,31 @@
+---
+title: KubeCon Europe 2021
+#linktitle: Videos
+weight: 80
+sidebar_multicard: false
+icon: kubernetes
+---
+
+![](https://cdn.sched.co/kccnceu2021/img/logo.jpg)
+
+## KubeCon Europe 2021
+
+We are thrilled to be part of [KubeCon + CloudNativeCon Europe 2021](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/)! Please visit us at our booth and chat with Keptn experts to learn all about the project.
+
+### Talks
+
+Please join Keptn maintainer Jürgen Etzlstorfer when he speaking about how to evaluate and improve resilience by putting Chaos Engineering techniques into continuous delivery. The talk is done together with Karthik Satchitanand, maintainer of LitmusChaos.
+
+**Putting Chaos Into Continuous Delivery to Increase Application Resiliency - Juergen Etzlstorfer, Dynatrace & Karthik Satchitanand, Mayadata**
+
+*Continuous Delivery practices have evolved significantly with the cloud-native paradigm. GitOps & Chaos Engineering are at the forefront of this new CD approach, with an ever-increasing pattern involving Git-backed pipeline definitions that implement “chaos stages” in pre-prod environments to gauge SLO compliance. In this talk, maintainers of the Keptn (Juergen) & LitmusChaos (Karthik) CNCF sandbox projects will discuss how you can construct pipelines that include chaos experimentation (mapped to declarative hypothesis around application steady-state) while simulating real-world load, and implement quality gates to ensure resilient applications are deployed into production. All this - in a GitOps native manner. They will also demonstrate how you can include chaos tests to your existing CD pipelines without the need of rewriting them.*
+
+
+**Find the session here:** https://sched.co/iEn7 
+
+### Office hours
+
+The Keptn team is hosting two office hours, which are an excellent opportunity for you to get to know the project and ask your questions to the Keptn maintainers.
+
+DATES TBA
+


### PR DESCRIPTION
Adding a landing page for KubeCon 2021 so we can provide some additional information around the event.

Signed-off-by: jetzlstorfer <juergen.etzlstorfer@dynatrace.com>