### PR TITLE
Disable relative URLs. fixes #794

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@
 languageCode = "en-us"
 title = "keptn | Cloud-native application life-cycle orchestration"
 theme = "hugo-serif-theme"
-relativeUrls = true
+relativeUrls = false
 enableEmoji = true
 
 ignoreFiles = [


### PR DESCRIPTION
As outlined in #794 the 404 pages have broken CSS.

Hugo is assuming the 404 page will appear under `/404/index.html`. But as the web server is not redirecting to 404 but just rewriting the request these paths are being messed up.

Switching off relative linking should not only resolve this issue but also avoid links like

```
<link rel="stylesheet" href="../../../../../../js/libs/doc/lightbox/css/lightbox.min.min.1bbb47ec548f1c47e276ce27971cdc27f8c803ee4bb96f064c72c7448f7c0f12.css">
```