### PR TITLE
keptn/keptn#3585 Describe service naming rule

### DIFF
--- a/content/docs/0.8.x/continuous_delivery/deployment_helm/index.md
+++ b/content/docs/0.8.x/continuous_delivery/deployment_helm/index.md
@@ -5,12 +5,14 @@ weight: 10
 keywords: [0.8.x-cd]
 ---
 
-Keptn uses [Helm v3](https://helm.sh/) for deploying onboarded services to a Kubernetes cluster. This is currently implemented in the [helm-service](https://github.com/keptn/keptn/tree/0.8.2/helm-service). The helm-service supports two deployment strategies explained below:
+Keptn uses [Helm v3](https://helm.sh/) for deploying [onboarded services](../../manage/service/) to a Kubernetes cluster. This is currently implemented in the [helm-service](https://github.com/keptn/keptn/tree/0.8.2/helm-service). 
+Keptn's helm-service supports the following deployment strategies:
 
 * **Direct deployments**
 * **Blue-green deployments**
+* **user-managed deployments** (experimental)
 
-The explanation is based on the provided Helm Chart for the carts microservice, see [Charts](https://github.com/keptn/examples/tree/0.8.2/onboarding-carts/carts) for details.
+The explanation below is based on the provided Helm Chart for the carts microservice, see [Charts](https://github.com/keptn/examples/tree/0.8.2/onboarding-carts/carts) for details.
 
 ## Direct deployments
 
@@ -26,7 +28,7 @@ NAME    READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES              
 carts   1/1     1            1           56m   carts        docker.io/keptnexamples/carts:0.11.1   app=carts
 ```
 
-When sending a new-artifact, we are updating the values.yaml file in the Helm Charts with the respective image name.
+When triggering a delivery (with a new artifact), we are updating the values.yaml file in the Helm Charts with the respective image name.
 
 * [chart/values.yaml](https://github.com/keptn/examples/blob/0.8.2/onboarding-carts/carts/values.yaml#L1)
 * [chart/templates/deployment.yaml](https://github.com/keptn/examples/blob/0.8.2/onboarding-carts/carts/templates/deployment.yaml#L22)
@@ -48,7 +50,7 @@ carts           0/0     0            0            3m   carts        docker.io/ke
 ```
 
 
-When a new artifact is deployed (e.g., 0.11.2), a canary deployment will be modified and scaled up.
+When triggering a delivery (with a new artifact, e.g., 0.11.2), a canary deployment will be modified and scaled up.
 
 ```
 NAME            READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES                                 SELECTOR

--- a/content/docs/0.8.x/manage/service/index.md
+++ b/content/docs/0.8.x/manage/service/index.md
@@ -18,7 +18,7 @@ After creating a project, Keptn allows creating a service or onboarding a servic
 * Keptn Version <= 0.8.2:
   Service name in the form `${PROJECT}-${STAGE}-${SERVICE}-generated` must be less than 53 characters (*Note*: this limitation comes from [Kubernetes/Helm](https://github.com/helm/helm/issues/6006))
 * Keptn Version >= 0.8.3:
-  Service name in must be less than 43 characters (*Note*: template was reduced to `${SERVICE}-generated` to allow longer service names)
+  Service name must be less than 43 characters (*Note*: template was reduced to `${SERVICE}-generated` to allow longer service names)
 
 ## Create a service
 

--- a/content/docs/0.8.x/manage/service/index.md
+++ b/content/docs/0.8.x/manage/service/index.md
@@ -12,6 +12,14 @@ After creating a project, Keptn allows creating a service or onboarding a servic
 
 - **Onboard a service:** This creates a new service and uploads the configuration to deploy the service. The configuration has to be a Helm Chart.
 
+## Service name restrictions
+
+* Service name must be a valid unix directory name (*Note*: for each service a directory with the corresponding name is created in the upstream git repository)
+* Keptn Version <= 0.8.2:
+  Service name in the form `${PROJECT}-${STAGE}-${SERVICE}-generated` must be less than 53 characters (*Note*: this limitation comes from [Kubernetes/Helm](https://github.com/helm/helm/issues/6006))
+* Keptn Version >= 0.8.3:
+  Service name in must be less than 43 characters (*Note*: template was reduced to `${SERVICE}-generated` to allow longer service names)
+
 ## Create a service
 
 * To create a service, use the [keptn create service](../../reference/cli/commands/keptn_create_service) command and provide the service and project name (`--project` flag): 


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

docs for keptn/keptn#3585

Preview: https://deploy-preview-807--keptn.netlify.app/docs/0.8.x/manage/service/