### PR TITLE
Correct the selector of the api-service

### DIFF
--- a/content/docs/0.8.x/operate/api_token/index.md
+++ b/content/docs/0.8.x/operate/api_token/index.md
@@ -167,7 +167,7 @@ In this section, the management of the API token of a Keptn installation is expl
 * Re-start API service since it requires the new token:
 
     ```console
-    kubectl delete pods -n keptn --selector=run=api-service
+    kubectl delete pods -n keptn --selector=app.kubernetes.io/name=api-service
     ```
 
 * Re-authenticate Keptn CLI as explained [here](../../reference/cli/commands/keptn_auth).


### PR DESCRIPTION
The selector of the api-service has changed from `run=api-service` to `app.kubernetes.io/name: api-service`, see https://github.com/keptn/keptn/blob/master/installer/manifests/keptn/charts/control-plane/templates/core.yaml#L52