### PR TITLE
keeping the announcment on keptn.sh

### DIFF
--- a/layouts/partials/announcement.html
+++ b/layouts/partials/announcement.html
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-12 d-flex flex-column text-center">
         
-        <h3>Keptn 0.8.3 is available! Find all <a href="./docs/news/release_announcements/keptn-083/">details on this release here</a>.</h3>
+        <h3>Keptn 0.8.3 is available! Find all <a href="./docs/news/release_announcements/keptn-083/">details on this release here</a>. </h3>
         
       </div>
     </div>

--- a/layouts/partials/announcement.html
+++ b/layouts/partials/announcement.html
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-12 d-flex flex-column text-center">
         
-        <h3>Keptn 0.8.3 is available! Find all <a href="https://github.com/keptn/keptn/releases/tag/0.8.3">details on this release here</a>.</h3>
+        <h3>Keptn 0.8.3 is available! Find all <a href="./docs/news/release_announcements/keptn-083/">details on this release here</a>.</h3>
         
       </div>
     </div>


### PR DESCRIPTION
I believe it would be a good idea to keep the announcements on keptn.sh instead of linking to github

Signed-off-by: jetzlstorfer <juergen.etzlstorfer@dynatrace.com>