### PR TITLE
ci: Add workflow to auto generate docs on receiving release-push event (#2927)

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -16,14 +16,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          path: 'keptn-docs'
-          fetch-depth: 0
-
-      - name: Checkout keptn core repo
-        uses: actions/checkout@v2
-        with:
-          repository: 'keptn/keptn'
-          path: 'keptn'
           fetch-depth: 0
 
       - name: Extract source branch
@@ -44,13 +36,11 @@ jobs:
         env:
           SOURCE_VERSION_SLUG: ${{ env.SOURCE_VERSION_SLUG }}
         run: |
-          cd keptn
-          full_path="../keptn-docs/content/docs/$SOURCE_VERSION_SLUG/reference/cli/commands"
+          full_path="./content/docs/$SOURCE_VERSION_SLUG/reference/cli/commands"
           if [[ ! -d $full_path ]]; then
             mkdir -p $full_path
           fi
           keptn generate docs --dir=$full_path
-          cd ..
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
@@ -63,7 +53,6 @@ jobs:
           branch: patch/update-keptn-docs-${{ env.SOURCE_TAG }}
           delete-branch: true
           base: master
-          path: 'keptn-docs'
           labels: 'automated pr'
           title: "Update keptn docs for release ${{ env.SOURCE_TAG }}"
           body: |

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -8,7 +8,7 @@ defaults:
 jobs:
   update-spec:
     env:
-      KEPTN_VERSION: '0.8.5'
+      KEPTN_VERSION: '0.8.6'
       SOURCE_REF: ${{ github.event.client_payload.ref }}
     runs-on: ubuntu-20.04
     steps:
@@ -16,12 +16,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: 'keptn-docs'
+          fetch-depth: 0
 
       - name: Checkout keptn core repo
         uses: actions/checkout@v2
         with:
           repository: 'keptn/keptn'
           path: 'keptn'
+          fetch-depth: 0
 
       - name: Install Keptn CLI
         id: install_keptn_cli
@@ -32,7 +34,7 @@ jobs:
         run: |
           # extract release branch version and replace minor version with x
           shopt -s extglob
-          echo "SOURCE_BRANCH=${SOURCE_REF#refs/heads/release-}" >> $GITHUB_ENV
+          echo "SOURCE_BRANCH=${SOURCE_REF#refs/tags/}" >> $GITHUB_ENV
           echo "SOURCE_VERSION_SLUG=${SOURCE_BRANCH/%.+([0-9])/.x}" >> $GITHUB_ENV
           shopt -u extglob
 

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,0 +1,63 @@
+name: Auto Update - Docs
+on:
+  repository_dispatch:
+    types: [release-push]
+defaults:
+  run:
+    shell: bash
+jobs:
+  update-spec:
+    env:
+      KEPTN_VERSION: '0.8.5'
+      SOURCE_REF: ${{ github.event.client_payload.ref }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: 'keptn-docs'
+
+      - name: Checkout keptn core repo
+        uses: actions/checkout@v2
+        with:
+          repository: 'keptn/keptn'
+          path: 'keptn'
+
+      - name: Install Keptn CLI
+        id: install_keptn_cli
+        run: |
+          curl -sL https://get.keptn.sh | KEPTN_VERSION=${{ env.KEPTN_VERSION }} bash
+
+      - name: Extract source branch
+        run: |
+          # extract release branch version and replace minor version with x
+          shopt -s extglob
+          echo "SOURCE_BRANCH=${SOURCE_REF#refs/heads/release-}" >> $GITHUB_ENV
+          echo "SOURCE_VERSION_SLUG=${SOURCE_BRANCH/%.+([0-9])/.x}" >> $GITHUB_ENV
+          shopt -u extglob
+
+      - name: Generate docs
+        env:
+          SOURCE_VERSION_SLUG: ${{ env.SOURCE_VERSION_SLUG }}
+        run: |
+          cd keptn
+          keptn generate docs --dir=../keptn-docs/content/docs/$SOURCE_VERSION_SLUG
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.KEPTN_BOT_TOKEN }}
+          commit-message: "Update keptn docs to release ${{ env.SOURCE_VERSION_SLUG }}"
+          committer: "keptn-bot <86361500+keptn-bot@users.noreply.github.com>"
+          author: "keptn-bot <86361500+keptn-bot@users.noreply.github.com>"
+          signoff: true
+          branch: patch/update-keptn-docs-${{ env.SOURCE_VERSION_SLUG }}
+          delete-branch: true
+          base: master
+          labels: "area:spec,automated pr,dependencies"
+          title: "Update keptn/spec to release ${{ env.SOURCE_VERSION_SLUG }}"
+          body: |
+            **This is an automated PR!**
+
+            Update keptn docs to latest keptn/keptn release
+            New version: ${{ env.SOURCE_BRANCH }}

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -30,7 +30,8 @@ jobs:
         run: |
           # extract release branch version and replace minor version with x
           shopt -s extglob
-          echo "SOURCE_TAG=${SOURCE_REF#refs/tags/}" >> $GITHUB_ENV
+          export "SOURCE_TAG=${SOURCE_REF#refs/tags/}"
+          echo $SOURCE_TAG >> $GITHUB_ENV
           echo "SOURCE_VERSION_SLUG=${SOURCE_TAG/%.+([0-9])/.x}" >> $GITHUB_ENV
           shopt -u extglob
 

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           cd keptn
           keptn generate docs --dir=../keptn-docs/content/docs/$SOURCE_VERSION_SLUG
+          cd ..
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
@@ -54,8 +55,9 @@ jobs:
           branch: patch/update-keptn-docs-${{ env.SOURCE_VERSION_SLUG }}
           delete-branch: true
           base: master
-          labels: "area:spec,automated pr,dependencies"
-          title: "Update keptn/spec to release ${{ env.SOURCE_VERSION_SLUG }}"
+          path: 'keptn-docs'
+          labels: "automated pr"
+          title: "Update keptn docs for release ${{ env.SOURCE_BRANCH }}"
           body: |
             **This is an automated PR!**
 

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -5,6 +5,8 @@ on:
 defaults:
   run:
     shell: bash
+env:
+  KEPTN_BOT: "keptn-bot <86361500+keptn-bot@users.noreply.github.com>"
 jobs:
   update-spec:
     env:
@@ -53,11 +55,11 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.KEPTN_BOT_TOKEN }}
-          commit-message: "Update keptn docs to release ${{ env.SOURCE_VERSION_SLUG }}"
-          committer: "keptn-bot <86361500+keptn-bot@users.noreply.github.com>"
-          author: "keptn-bot <86361500+keptn-bot@users.noreply.github.com>"
+          commit-message: "Update keptn docs to release ${{ env.SOURCE_TAG }}"
+          committer: ${{ env.KEPTN_BOT }}
+          author: ${{ env.KEPTN_BOT }}
           signoff: true
-          branch: patch/update-keptn-docs-${{ env.SOURCE_VERSION_SLUG }}
+          branch: patch/update-keptn-docs-${{ env.SOURCE_TAG }}
           delete-branch: true
           base: master
           path: 'keptn-docs'

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -41,7 +41,11 @@ jobs:
           SOURCE_VERSION_SLUG: ${{ env.SOURCE_VERSION_SLUG }}
         run: |
           cd keptn
-          keptn generate docs --dir=../keptn-docs/content/docs/$SOURCE_VERSION_SLUG
+          full_path="../keptn-docs/content/docs/$SOURCE_VERSION_SLUG/reference/cli/commands"
+          if [[ ! -d $full_path ]]; then
+            mkdir -p $full_path
+          fi
+          keptn generate docs --dir=$full_path
           cd ..
 
       - name: Create Pull Request
@@ -56,7 +60,7 @@ jobs:
           delete-branch: true
           base: master
           path: 'keptn-docs'
-          labels: "automated pr"
+          labels: 'automated pr'
           title: "Update keptn docs for release ${{ env.SOURCE_BRANCH }}"
           body: |
             **This is an automated PR!**

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -8,7 +8,6 @@ defaults:
 jobs:
   update-spec:
     env:
-      KEPTN_VERSION: '0.8.6'
       SOURCE_REF: ${{ github.event.client_payload.ref }}
     runs-on: ubuntu-20.04
     steps:
@@ -29,14 +28,14 @@ jobs:
         run: |
           # extract release branch version and replace minor version with x
           shopt -s extglob
-          echo "SOURCE_BRANCH=${SOURCE_REF#refs/tags/}" >> $GITHUB_ENV
-          echo "SOURCE_VERSION_SLUG=${SOURCE_BRANCH/%.+([0-9])/.x}" >> $GITHUB_ENV
+          echo "SOURCE_TAG=${SOURCE_REF#refs/tags/}" >> $GITHUB_ENV
+          echo "SOURCE_VERSION_SLUG=${SOURCE_TAG/%.+([0-9])/.x}" >> $GITHUB_ENV
           shopt -u extglob
 
       - name: Install Keptn CLI
         id: install_keptn_cli
         run: |
-          curl -sL https://get.keptn.sh | KEPTN_VERSION=${{ env.KEPTN_VERSION }} bash
+          curl -sL https://get.keptn.sh | KEPTN_VERSION=${{ env.SOURCE_TAG }} bash
 
       - name: Generate docs
         env:
@@ -63,9 +62,9 @@ jobs:
           base: master
           path: 'keptn-docs'
           labels: 'automated pr'
-          title: "Update keptn docs for release ${{ env.SOURCE_BRANCH }}"
+          title: "Update keptn docs for release ${{ env.SOURCE_TAG }}"
           body: |
             **This is an automated PR!**
 
             Update keptn docs to latest keptn/keptn release
-            New version: ${{ env.SOURCE_BRANCH }}
+            New version: ${{ env.SOURCE_TAG }}

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -25,11 +25,6 @@ jobs:
           path: 'keptn'
           fetch-depth: 0
 
-      - name: Install Keptn CLI
-        id: install_keptn_cli
-        run: |
-          curl -sL https://get.keptn.sh | KEPTN_VERSION=${{ env.KEPTN_VERSION }} bash
-
       - name: Extract source branch
         run: |
           # extract release branch version and replace minor version with x
@@ -37,6 +32,11 @@ jobs:
           echo "SOURCE_BRANCH=${SOURCE_REF#refs/tags/}" >> $GITHUB_ENV
           echo "SOURCE_VERSION_SLUG=${SOURCE_BRANCH/%.+([0-9])/.x}" >> $GITHUB_ENV
           shopt -u extglob
+
+      - name: Install Keptn CLI
+        id: install_keptn_cli
+        run: |
+          curl -sL https://get.keptn.sh | KEPTN_VERSION=${{ env.KEPTN_VERSION }} bash
 
       - name: Generate docs
         env:


### PR DESCRIPTION
**This PR**
* adds a workflow to automatically update the keptn CLI docs when a new keptn/keptn version (tag) is pushed
* creates a PR against this repo to update the docs which can then be reviewed and accepted

#### Open Tasks
* [x] update release checklist to incorporate newly automated steps

Signed-off-by: Moritz Wiesinger <moritz.wiesinger@dynatrace.com>