### PR TITLE
Contributor Guide: Document non-code contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contribute to the Keptn Website
+
+This is the repository of the [Keptn](https://keptn.sh) website, which uses the [Hugo static website generator framework](http://gohugo.io).
+Keptn is a message-driven control-plane for application delivery and automated operations.
+
+## Run locally
+
+Perform the following steps to create a copy of this repository on your local machine:
+
+1. Fork the Keptn repository.
+A copy of this repository is available in your GitHub account.
+
+2. Clone the forked repository in a local directory.
+    ```
+    git clone https://github.com/UserName/keptn.github.io
+    ```
+	Where UserName is your github username. The keptn.github.io directory is available in the local directory.
+
+3. Install the **extended** version of [Hugo](http://gohugo.io) in [Version 0.53](https://github.com/gohugoio/hugo/releases/tag/v0.53) (see [netlify.toml](netlify.toml) - `HUGO_VERSION = "0.53"`).
+The themes directory on your local machine (localdirectory/keptn.github.io/themes) is empty because the Hugo serif theme is available at https://github.com/zerostaticthemes/hugo-serif-theme. You need to load the git submodule (see next step) to install this theme.
+
+4. Install the git submodule in the themes directory.
+    ```
+    git submodule update --init --recursive --force
+    ```
+5. Execute the `hugo server -D` command from the root folder:
+    ```
+    hugo server -D
+    ```
+6. Enter the following in a browser to view the website:
+    ```
+    http://localhost:1313/
+
+	# Press Ctrl+C to stop the Hugo server
+    ```
+
+Start contributing! Note that all edits to the files are updated immediately.
+
+## Push to production
+
+Before you push to production, make sure to run the following command in order to get the correctly built files:
+
+```
+hugo
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contribute to the Keptn Website
 
 This is the repository of the [Keptn](https://keptn.sh) website, which uses the [Hugo static website generator framework](http://gohugo.io).
-Keptn is a message-driven control-plane for application delivery and automated operations.
+Keptn is a event-driven control-plane for application delivery and automated operations.
 
 ## Run locally
 

--- a/README.md
+++ b/README.md
@@ -1,50 +1,19 @@
-# Contribute to the Keptn Website
+# Keptn Website
 
-This is the repository of the [Keptn](https://keptn.sh) website, which uses the [Hugo static website generator framework](http://gohugo.io).
-Keptn is a message-driven control-plane for application delivery and automated operations.
-## Run locally
+The Keptn project has a static website powered by [Hugo](https://gohugo.io/).
+This repository contains the most of the contents though some of the resources hosted in separate repositories.
 
-Perform the following steps to create a copy of this repository on your local machine:
+Related repositories:
 
-1. Fork the Keptn repository.
-A copy of this repository is available in your GitHub account.
+* [Keptn Tutorials](https://github.com/keptn/tutorials)
+* [Keptn Examples](https://github.com/keptn/examples)
 
-2. Clone the forked repository in a local directory.
-    ```
-    git clone https://github.com/UserName/keptn.github.io
-    ```
-	Where UserName is your github username. The keptn.github.io directory is available in the local directory.
+## Contributing
 
-3. Install the **extended** version of [Hugo](http://gohugo.io) in [Version 0.53](https://github.com/gohugoio/hugo/releases/tag/v0.53) (see [netlify.toml](netlify.toml) - `HUGO_VERSION = "0.53"`).
-The themes directory on your local machine (localdirectory/keptn.github.io/themes) is empty because the Hugo serif theme is available at https://github.com/zerostaticthemes/hugo-serif-theme. You need to load the git submodule (see next step) to install this theme.
+See the [Contributor Guide](./CONTRIBUTING.md)
 
-4. Install the git submodule in the themes directory.
-    ```
-    git submodule update --init --recursive --force
-    ```
-5. Execute the `hugo server -D` command from the root folder:
-    ```
-    hugo server -D
-    ```
-6. Enter the following in a browser to view the website:
-    ```
-    http://localhost:1313/
+## License
 
-	# Press Ctrl+C to stop the Hugo server
-    ```
-
-Start contributing! Note that all edits to the files are updated immediately.
-
-## Push to production
-
-Before you push to production, make sure to run the following command in order to get the correctly built files:
-
-```
-hugo
-```
-
-# License
-
-keptn.sh is licensed under an [Apache 2.0 license](./LICENSE).
+The Keptn website engine (keptn.sh) is licensed under the [Apache License Version 2.0](./LICENSE).
 
 The Keptn documentation (e.g., `.md` files in the `/content/docs` folder) is licensed under a [CC-BY-4.0 license](./LICENSE-docs).

--- a/content/community/contributing/index.md
+++ b/content/community/contributing/index.md
@@ -83,4 +83,4 @@ reach out to the community in the `#advocacy-and-outreach` channel on the Keptn 
 ## Other contributions
 
 Any contributions will be appreciated even if they aren't listed here yet!
-We welcome contributors with any backgrounds and levels of experiences: code reviews, design and artwork, organizing events, content management, testing, issue triage, localization, etc.
+We welcome contributors with any backgrounds and levels of experience: code reviews, design and artwork, organizing events, content management, testing, issue triage, localization, etc.

--- a/content/community/contributing/index.md
+++ b/content/community/contributing/index.md
@@ -23,5 +23,64 @@ If you want to contribute an **integration** to Keptn, please take a look at the
 
 💡 Did you know that there is a [**template to get started with new integrations**](https://github.com/keptn-sandbox/keptn-service-template-go)? The Keptn team is maitaining it as a good first start and skeleton for new Keptn integrations. It is written in Golang. But feel free to submit your contribution in other languages as well.
 
+## Contributing to Keptn Documentation
 
+Documentation is essential to Keptn user and developer experience.
+We invite amateur and professional tech writers to participate in the documentation efforts by creating new content or improving the existing content.
+We also look for reviewers and copy editors who can help other contributors with documentation changes.
+If you are interested, join the `#keptn-docs` channel on the Keptn Slack workspace.
 
+Major documentation areas:
+
+* Documentation ([keptn.sh/docs](https://keptn.sh/docs/)) - extend and improve the documentation for Keptn
+  * [GitHub Repository](https://github.com/keptn/keptn.github.io/)
+  * [How to contribute?](https://github.com/keptn/keptn.github.io/blob/master/CONTRIBUTING.md) 
+  * [Good First Issues](https://github.com/keptn/keptn.github.io/labels/good%20first%20issue)
+* Tutorials ([tutorials.keptn.sh](https://tutorials.keptn.sh/)) - add new tutorials and extend the existing ones to help newcomer users to study Keptn, and to integrate it into their application management.
+  * [GitHub Repository](https://github.com/keptn/tutorials)
+  * [How to contribute?](https://github.com/keptn/tutorials/blob/master/CONTRIBUTING.md)
+  * [Good First Issues](https://github.com/keptn/tutorials/labels/good%20first%20issue)
+* Services and Components Documentation - many components, e.g. the [Prometheus Service for Keptn](https://github.com/keptn-contrib/prometheus-service), have documentation as a part of their repositories. Patches are welcome there too!
+* [Keptn Examples](https://github.com/keptn/examples) - expand and document Keptn examples that can be used by end users
+* Contributing guidelines
+
+## Spread the word about Keptn!
+
+In the Keptn community we heavily rely on the community members to promote Keptn among their professional networks and social media.
+Any contributions will be appreciated!
+
+A few examples:
+
+* Share your experiences, e.g. by writing a blogpost or speaking about Keptn at meetups, conferences, or at the [Keptn user group meetings](/community/meetings/).
+* Follow the Keptn community on social media and re-post the content.
+  [@keptnProject on Twitter](https://twitter.com/keptnProject),
+  [KeptnProject on LinkedIn](https://www.linkedin.com/company/keptnproject).
+* Share news about Keptn features and its community through your network and social media.
+
+If you are interested in Keptn advocacy and/or want to promote your content,
+join the `#advocacy-and-outreach` channel on the Keptn Slack.
+
+## Donations
+
+At the moment the Keptn project does NOT accept monetary contributions.
+Donating some time is the best way to help the community.
+If you are interested in helping with money,
+consider donating to one of the upstream open source projects used in Keptn,
+or to open source development tools used by Keptn.
+
+In the future we plan to organize bigger in-person and online community events.
+If you want to join as sponsor, reach out to the community in the `#advocacy-and-outreach` channel on the Keptn Slack.
+
+## Internships and Mentorship programs
+
+Keptn intends to participate in global mentorship programs like Google Summer of Code.
+We also have an account on [LFX Mentorship](https://mentorship.lfx.linuxfoundation.org/#projects_all)
+and can host our own mentorship programs for important topics contributing to the Keptn roadmap.
+
+If you are interested in mentorship programs as a potential mentor or mentee,
+reach out to the community in the `#advocacy-and-outreach` channel on the Keptn Slack.
+
+## Other contributions
+
+Any contributions will be appreciated even if they aren't listed here yet!
+We welcome contributors with any backgrounds and levels of experiences: code reviews, design and artwork, organizing events, content management, testing, issue triage, localization, etc.


### PR DESCRIPTION
This change initializes contributor guidelines for non-code contributions:

* Documentation
* Advocacy and Outreach
* Mentorship programs and internships
* Recommendations for monetary donations that we do not accept at the moment (right?)
* Placeholder for other types of contributions, e.g. design

Contributes to https://github.com/keptn/community/issues/82 . Also fixes #862 by moving the contributing content to a separate page.

Signed-off-by: Oleg Nenashev <o.v.nenashev@gmail.com>

## Screenshots

![image](https://user-images.githubusercontent.com/3000480/145835829-c8e5d61c-122b-44b1-9682-f53d488164d6.png)
