### PR TITLE
docs: Change from carts:0.11 to carts:0.13 for Keptn 0.11.x

### DIFF
--- a/content/docs/0.11.x/continuous_delivery/delivery_assistant/index.md
+++ b/content/docs/0.11.x/continuous_delivery/delivery_assistant/index.md
@@ -80,7 +80,7 @@ If this task is in place, you can control how to proceed with the delivery depen
             "result": "warning",
             "service": "carts",
             "stage": "production",
-            "tag": "0.11.2",
+            "tag": "0.13.2",
             "teststrategy": "performance"
         },
         "id": "5bf26759-4afa-4045-8ccf-81bc398c2fcd",
@@ -98,7 +98,7 @@ If this task is in place, you can control how to proceed with the delivery depen
     Starting to send approval.finished event
     
      OPTION VERSION EVALUATION  
-     (1)  0.11.2  n/a   
+     (1)  0.13.2  n/a   
     Select the option to approve or decline: 
     1
     Do you want to (a)pprove or (d)ecline: 
@@ -137,7 +137,7 @@ If this task is in place, you can control how to proceed with the delivery depen
     "project": "ck-sockshop",
     "service": "carts",
     "stage": "production",
-    "tag": "0.11.2",
+    "tag": "0.13.2",
     "teststrategy": "performance"
   }
 }

--- a/content/docs/0.11.x/continuous_delivery/deployment_helm/index.md
+++ b/content/docs/0.11.x/continuous_delivery/deployment_helm/index.md
@@ -25,7 +25,7 @@ $ kubectl get deployments -n sockshop-dev carts -owide
 
 ```
 NAME    READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES                                 SELECTOR
-carts   1/1     1            1           56m   carts        docker.io/keptnexamples/carts:0.11.1   app=carts
+carts   1/1     1            1           56m   carts        docker.io/keptnexamples/carts:0.13.1   app=carts
 ```
 
 When triggering a delivery (with a new artifact), we are updating the values.yaml file in the Helm Charts with the respective image name.
@@ -45,8 +45,8 @@ $ kubectl get deployments -n sockshop-staging carts carts-primary -owide
 
 ```
 NAME            READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES                                 SELECTOR
-carts-primary   1/1     1            1           56m   carts        docker.io/keptnexamples/carts:0.11.1   app=carts-primary
-carts           0/0     0            0            3m   carts        docker.io/keptnexamples/carts:0.11.2   app=carts
+carts-primary   1/1     1            1           56m   carts        docker.io/keptnexamples/carts:0.13.1   app=carts-primary
+carts           0/0     0            0            3m   carts        docker.io/keptnexamples/carts:0.13.2   app=carts
 ```
 
 
@@ -54,8 +54,8 @@ When triggering a delivery (with a new artifact, e.g., 0.11.2), a canary deploym
 
 ```
 NAME            READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES                                 SELECTOR
-carts-primary   1/1     1            1           57m   carts        docker.io/keptnexamples/carts:0.11.1   app=carts-primary
-carts           0/1     1            1            1m   carts        docker.io/keptnexamples/carts:0.11.2   app=carts
+carts-primary   1/1     1            1           57m   carts        docker.io/keptnexamples/carts:0.13.1   app=carts-primary
+carts           0/1     1            1            1m   carts        docker.io/keptnexamples/carts:0.13.2   app=carts
 ```
 
 The primary deployment is always available (and called `carts-primary`). The canary deployment (called `carts`) gets scaled up in the case of a new-artifact event (e.g., in this case someone has sent a new-artifact for 0.11.2). Traffic is shifted to the canary release.
@@ -64,8 +64,8 @@ Once testing has finished, the primary deployment is upgraded to the new version
 
 ```
 NAME            READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES                                 SELECTOR
-carts-primary   1/1     1            1            3m   carts        docker.io/keptnexamples/carts:0.11.2   app=carts-primary
-carts           1/1     1            1            1d   carts        docker.io/keptnexamples/carts:0.11.2   app=carts
+carts-primary   1/1     1            1            3m   carts        docker.io/keptnexamples/carts:0.13.2   app=carts-primary
+carts           1/1     1            1            1d   carts        docker.io/keptnexamples/carts:0.13.2   app=carts
 ```
 
 After a new pod for the primary deployment has been successfully deployed, traffic is shifted to the primary deployment
@@ -73,8 +73,8 @@ After a new pod for the primary deployment has been successfully deployed, traff
 
 ```
 NAME            READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES                                 SELECTOR
-carts-primary   1/1     1            1            4m   carts        docker.io/keptnexamples/carts:0.11.2   app=carts-primary
-carts           0/0     0            0            1d   carts        docker.io/keptnexamples/carts:0.11.2   app=carts
+carts-primary   1/1     1            1            4m   carts        docker.io/keptnexamples/carts:0.13.2   app=carts-primary
+carts           0/0     0            0            1d   carts        docker.io/keptnexamples/carts:0.13.2   app=carts
 ```
 
 

--- a/content/docs/0.11.x/continuous_delivery/multi_stage/index.md
+++ b/content/docs/0.11.x/continuous_delivery/multi_stage/index.md
@@ -149,7 +149,7 @@ keptn trigger delivery --project=$PROJECTNAME --service=$SERVICENAME --image=$IM
     "stage": "[STAGENAME]",
     "configurationChange": {
       "values": {
-        "image": "keptn-examples/carts:0.11.3"
+        "image": "keptn-examples/carts:0.13.3"
       }
     }
   },

--- a/content/docs/0.11.x/manage/service/index.md
+++ b/content/docs/0.11.x/manage/service/index.md
@@ -33,7 +33,7 @@ After creating a service, you need to provide a Helm Chart for the service to de
 1. The Helm chart _has_ to contain a `values.yaml` file with at least the `image` and `replicaCount` parameter for the deployment. These `image` and `replicaCount` parameters have to be used in the deployment. An example is shown below:
   
   ```yaml
-  image: docker.io/keptnexamples/carts:0.11.1
+  image: docker.io/keptnexamples/carts:0.13.1
   replicaCount: 1
   ```
 


### PR DESCRIPTION
Due to a new release of the [carts service](https://github.com/keptn-sockshop/carts/releases/tag/0.13.0), an update of the docs for the newest Keptn version had to be done. 

Signed-off-by: Johannes <johannes.braeuer@dynatrace.com>