### PR TITLE
Disable the public demo

### DIFF
--- a/layouts/partials/intro.html
+++ b/layouts/partials/intro.html
@@ -25,11 +25,13 @@
               Install Keptn!
             </a>
           </div>
+          <!--TODO(oleg_nenashev): Recover once the new demo is created in https://github.com/keptn/community/issues/89
           <div class="d-block">
-            <a class="d-inline-block button button--filledWhite" href="https://tutorials.keptn.sh/tutorials/keptn-public-demo-08/index.html">
+            <a class="d-inline-block button button--filledWhite" href="https://tutorials.keptn.sh/tutorials/keptn-public-demo-011/index.html">
               Explore live demo
             </a>
-          </div> 
+          </div>
+          --> 
           <!-- <div class="d-block">
             <a class="d-inline-block button button--filledWhite" href="https://github.com/keptn/keptn">
               Keptn on Github


### PR DESCRIPTION
Until https://github.com/keptn/community/issues/89 is ready, we cannot serve the public demo.

Tutorials are also updated by https://github.com/keptn/tutorials/pull/216