### PR TITLE
docs: Update helm chart URL to point to new chart repository

### DIFF
--- a/content/docs/0.10.x/operate/advanced_install_options/index.md
+++ b/content/docs/0.10.x/operate/advanced_install_options/index.md
@@ -60,21 +60,21 @@ The following flags are available:
 ### Example: Use a LoadBalancer for api-gateway-nginx
 
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.10.0 --repo=https://storage.googleapis.com/keptn-installer --set=control-plane.apiGatewayNginx.type=LoadBalancer
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.10.0 --repo=https://charts.keptn.sh --set=control-plane.apiGatewayNginx.type=LoadBalancer
 ```
 
 ### Example: Install execution plane for Continuous Delivery use-case
 
 For example, the **Control Plane with the Execution Plane (for Continuous Delivery)** can be installed by the following command:
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.10.0 --repo=https://storage.googleapis.com/keptn-installer --set=continuous-delivery.enabled=true
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.10.0 --repo=https://charts.keptn.sh --set=continuous-delivery.enabled=true
 ```
 
 ### Example: Install execution plane for Continuous Delivery use-case and use a LoadBalancer for api-gateway-nginx
 
 For example, the **Control Plane with the Execution Plane (for Continuous Delivery)** and a `LoadBalancer` for exposing Keptn can be installed by the following command:
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.10.0 --repo=https://storage.googleapis.com/keptn-installer --set=continuous-delivery.enabled=true,control-plane.apiGatewayNginx.type=LoadBalancer
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.10.0 --repo=https://charts.keptn.sh --set=continuous-delivery.enabled=true,control-plane.apiGatewayNginx.type=LoadBalancer
 ```
 
 ### Example: Execute Helm upgrade without Internet connectivity
@@ -153,7 +153,7 @@ For example, if a user sets `control-plane.prefixPath=/mykeptn` in the Helm inst
 the Keptn API is located under `http://HOSTNAME/mykeptn/api` and the Keptn Bridge is located under `http://HOSTNAME/mykeptn/bridge`:
 
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.10.0 --repo=https://storage.googleapis.com/keptn-installer --set=control-plane.apiGatewayNginx.type=LoadBalancer,continuous-delivery.enabled=true,control-plane.prefixPath=/mykeptn
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.10.0 --repo=https://charts.keptn.sh --set=control-plane.apiGatewayNginx.type=LoadBalancer,continuous-delivery.enabled=true,control-plane.prefixPath=/mykeptn
 ```
 
 ### Example: Install Keptn with externally hosted MongoDB

--- a/content/docs/0.10.x/operate/upgrade/index.md
+++ b/content/docs/0.10.x/operate/upgrade/index.md
@@ -45,7 +45,7 @@ keptn upgrade
     * Please [verify that you are connected to the correct Kubernetes cluster](../../troubleshooting/#verify-kubernetes-context-with-keptn-installation)
 before executing this command.
 
-    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.10.0.tgz](https://storage.googleapis.com/keptn-installer/keptn-0.10.0.tgz)
+    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.10.0.tgz](https://charts.keptn.sh/packages/keptn-0.10.0.tgz)
 
 **Note:** If you have manually modified your Keptn deployment, e.g., you deleted the Kubernetes Secret `bridge-credentials` for disabling basic auth, the `keptn upgrade` command will not detect the modification. Please re-apply your modification after performing the upgrade.
 

--- a/content/docs/0.11.x/operate/advanced_install_options/index.md
+++ b/content/docs/0.11.x/operate/advanced_install_options/index.md
@@ -33,21 +33,21 @@ The full list of available flags can be found in the [helm-charts](https://githu
 ### Example: Use a LoadBalancer for api-gateway-nginx
 
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.11.4 --repo=https://storage.googleapis.com/keptn-installer --set=control-plane.apiGatewayNginx.type=LoadBalancer
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.11.4 --repo=https://charts.keptn.sh --set=control-plane.apiGatewayNginx.type=LoadBalancer
 ```
 
 ### Example: Install execution plane for Continuous Delivery use-case
 
 For example, the **Control Plane with the Execution Plane (for Continuous Delivery)** can be installed by the following command:
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.11.4 --repo=https://storage.googleapis.com/keptn-installer --set=continuous-delivery.enabled=true
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.11.4 --repo=https://charts.keptn.sh --set=continuous-delivery.enabled=true
 ```
 
 ### Example: Install execution plane for Continuous Delivery use-case and use a LoadBalancer for api-gateway-nginx
 
 For example, the **Control Plane with the Execution Plane (for Continuous Delivery)** and a `LoadBalancer` for exposing Keptn can be installed by the following command:
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.11.4 --repo=https://storage.googleapis.com/keptn-installer --set=continuous-delivery.enabled=true,control-plane.apiGatewayNginx.type=LoadBalancer
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.11.4 --repo=https://charts.keptn.sh --set=continuous-delivery.enabled=true,control-plane.apiGatewayNginx.type=LoadBalancer
 ```
 
 ### Example: Execute Helm upgrade without Internet connectivity
@@ -126,7 +126,7 @@ For example, if a user sets `control-plane.prefixPath=/mykeptn` in the Helm inst
 the Keptn API is located under `http://HOSTNAME/mykeptn/api` and the Keptn Bridge is located under `http://HOSTNAME/mykeptn/bridge`:
 
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.11.4 --repo=https://storage.googleapis.com/keptn-installer --set=control-plane.apiGatewayNginx.type=LoadBalancer,continuous-delivery.enabled=true,control-plane.prefixPath=/mykeptn
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.11.4 --repo=https://charts.keptn.sh --set=control-plane.apiGatewayNginx.type=LoadBalancer,continuous-delivery.enabled=true,control-plane.prefixPath=/mykeptn
 ```
 
 ### Example: Install Keptn with externally hosted MongoDB

--- a/content/docs/0.11.x/operate/upgrade/index.md
+++ b/content/docs/0.11.x/operate/upgrade/index.md
@@ -51,7 +51,7 @@ aliases:
    * If the CLI still complains about the context, please use the Helm approach to upgrade your cluster:
 
    ```console
-   helm upgrade keptn keptn --install -n keptn --create-namespace --repo=https://storage.googleapis.com/keptn-installer --version=0.11.4 --reuse-values --wait
+   helm upgrade keptn keptn --install -n keptn --create-namespace --repo=https://charts.keptn.sh --version=0.11.4 --reuse-values --wait
    ```
 
 * :warning: **Step 3.** If you are using the **jmeter-service** or **helm-service**, upgrade them to 0.11.4 using the following commands: 
@@ -102,7 +102,7 @@ aliases:
    ```
 
       * Please [verify that you are connected to the correct Kubernetes cluster](../../troubleshooting/#verify-kubernetes-context-with-keptn-installation) before executing this command.
-      * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.11.4.tgz](https://storage.googleapis.com/keptn-installer/keptn-0.11.4.tgz)
+      * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.11.4.tgz](https://charts.keptn.sh/packages/keptn-0.11.4.tgz)
 
 
 * **Step 4.** Restore your Mongo DB and configuration service data according to the steps in the [restore guide](../../operate/backup_and_restore).

--- a/content/docs/0.12.x/operate/advanced_install_options/index.md
+++ b/content/docs/0.12.x/operate/advanced_install_options/index.md
@@ -33,21 +33,21 @@ The full list of available flags can be found in the [helm-charts](https://githu
 ### Example: Use a LoadBalancer for api-gateway-nginx
 
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.12.0 --repo=https://storage.googleapis.com/keptn-installer --set=control-plane.apiGatewayNginx.type=LoadBalancer
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.12.0 --repo=https://charts.keptn.sh --set=control-plane.apiGatewayNginx.type=LoadBalancer
 ```
 
 ### Example: Install execution plane for Continuous Delivery use-case
 
 For example, the **Control Plane with the Execution Plane (for Continuous Delivery)** can be installed by the following command:
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.12.0 --repo=https://storage.googleapis.com/keptn-installer --set=continuous-delivery.enabled=true
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.12.0 --repo=https://charts.keptn.sh --set=continuous-delivery.enabled=true
 ```
 
 ### Example: Install execution plane for Continuous Delivery use-case and use a LoadBalancer for api-gateway-nginx
 
 For example, the **Control Plane with the Execution Plane (for Continuous Delivery)** and a `LoadBalancer` for exposing Keptn can be installed by the following command:
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.12.0 --repo=https://storage.googleapis.com/keptn-installer --set=continuous-delivery.enabled=true,control-plane.apiGatewayNginx.type=LoadBalancer
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.12.0 --repo=https://charts.keptn.sh --set=continuous-delivery.enabled=true,control-plane.apiGatewayNginx.type=LoadBalancer
 ```
 
 ### Example: Execute Helm upgrade without Internet connectivity
@@ -126,7 +126,7 @@ For example, if a user sets `control-plane.prefixPath=/mykeptn` in the Helm inst
 the Keptn API is located under `http://HOSTNAME/mykeptn/api` and the Keptn Bridge is located under `http://HOSTNAME/mykeptn/bridge`:
 
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.12.0 --repo=https://storage.googleapis.com/keptn-installer --set=control-plane.apiGatewayNginx.type=LoadBalancer,continuous-delivery.enabled=true,control-plane.prefixPath=/mykeptn
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.12.0 --repo=https://charts.keptn.sh --set=control-plane.apiGatewayNginx.type=LoadBalancer,continuous-delivery.enabled=true,control-plane.prefixPath=/mykeptn
 ```
 
 ### Example: Install Keptn with externally hosted MongoDB

--- a/content/docs/0.12.x/operate/upgrade/index.md
+++ b/content/docs/0.12.x/operate/upgrade/index.md
@@ -49,7 +49,7 @@ aliases:
    * If the CLI still complains about the context, please use the Helm approach to upgrade your cluster:
 
    ```console
-   helm upgrade keptn keptn --install -n keptn --create-namespace --repo=https://storage.googleapis.com/keptn-installer --version=0.12.0 --reuse-values --wait
+   helm upgrade keptn keptn --install -n keptn --create-namespace --repo=https://charts.keptn.sh --version=0.12.0 --reuse-values --wait
    ```
 
 * :warning: **Step 3.** If you are using the **jmeter-service** or **helm-service**, upgrade them to 0.12.0 using the following commands: 

--- a/content/docs/0.7.x/operate/advanced_install_options/index.md
+++ b/content/docs/0.7.x/operate/advanced_install_options/index.md
@@ -33,26 +33,26 @@ The following flags are available:
 ### Example: Use a LoadBalancer for api-gateway-nginx
 
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.7.3 --repo=https://storage.googleapis.com/keptn-installer --set=control-plane.apiGatewayNginx.type=LoadBalancer
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.7.3 --repo=https://charts.keptn.sh --set=control-plane.apiGatewayNginx.type=LoadBalancer
 ```
 
 ### Example: Install execution plane for Continuous Delivery use-case
 
 For example, the **Control Plane with the Execution Plane (for Continuous Delivery)** can be installed by the following command:
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.7.3 --repo=https://storage.googleapis.com/keptn-installer --set=continuous-delivery.enabled=true
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.7.3 --repo=https://charts.keptn.sh --set=continuous-delivery.enabled=true
 ```
 
 ### Example: Install execution plane for Continuous Delivery use-case and use a LoadBalancer for api-gateway-nginx
 
 For example, the **Control Plane with the Execution Plane (for Continuous Delivery)** and a `LoadBalancer` for exposing Keptn can be installed by the following command:
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.7.3 --repo=https://storage.googleapis.com/keptn-installer --set=continuous-delivery.enabled=true,control-plane.apiGatewayNginx.type=LoadBalancer
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.7.3 --repo=https://charts.keptn.sh --set=continuous-delivery.enabled=true,control-plane.apiGatewayNginx.type=LoadBalancer
 ```
 
 ### Example: Execute Helm upgrade without Internet connectivity
 
-* Download the Helm chart from [keptn-installer/keptn-0.7.3.tgz](https://storage.googleapis.com/keptn-installer/keptn-0.7.3.tgz) and move it to the machine that has no Internet connectivity, but should perform the installation:
+* Download the Helm chart from [keptn-installer/keptn-0.7.3.tgz](https://charts.keptn.sh/packages/keptn-0.7.3.tgz) and move it to the machine that has no Internet connectivity, but should perform the installation:
 
 * To install the **Control Plane with the Execution Plane (for Continuous Delivery)** and a `LoadBalancer` for exposing Keptn, execute the following command. 
 **Note:** Reference the Helm chart stored locally instead of a repository and version:
@@ -64,7 +64,7 @@ Furthermore, Keptn's Helm chart allows you to set all images, which can be espec
 handy in air-gapped systems where you cannot access DockerHub for pulling the images.
 For example, here all images are pulled from a registry with the URL `YOUR_REGISTRY/`
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.7.3 --repo=https://storage.googleapis.com/keptn-installer --set=control-plane.apiGatewayNginx.type=LoadBalancer,continuous-delivery.enabled=true,\
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.7.3 --repo=https://charts.keptn.sh --set=control-plane.apiGatewayNginx.type=LoadBalancer,continuous-delivery.enabled=true,\
 control-plane.mongodb.image.repository=YOUR_REGISTRY/centos/mongodb-36-centos7,\
 control-plane.nats.nats.image=YOUR_REGISTRY/nats:2.1.7-alpine3.11,\
 control-plane.nats.reloader.image=YOUR_REGISTRY/connecteverything/nats-server-config-reloader:0.6.0,\
@@ -115,5 +115,5 @@ By specifying a value for `control-plane.prefixPath`, the used prefix for the ro
 For example, if a user sets `control-plane.prefixPath=/mykeptn` in the Helm install/upgrade command,
 the Keptn API is located under `http://HOSTNAME/mykeptn/api` and the Keptn Bridge is located under `http://HOSTNAME/mykeptn/bridge`:
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.7.3 --repo=https://storage.googleapis.com/keptn-installer --set=control-plane.apiGatewayNginx.type=LoadBalancer,continuous-delivery.enabled=true,control-plane.prefixPath=/mykeptn
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.7.3 --repo=https://charts.keptn.sh --set=control-plane.apiGatewayNginx.type=LoadBalancer,continuous-delivery.enabled=true,control-plane.prefixPath=/mykeptn
 ```

--- a/content/docs/0.7.x/operate/upgrade/index.md
+++ b/content/docs/0.7.x/operate/upgrade/index.md
@@ -45,7 +45,7 @@ keptn upgrade
     * Please [verify that you are connected to the correct Kubernetes cluster](../../troubleshooting/#verify-kubernetes-context-with-keptn-installation)
 before executing this command.
     
-    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.7.3.tgz](https://storage.googleapis.com/keptn-installer/keptn-0.7.3.tgz)
+    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.7.3.tgz](https://charts.keptn.sh/packages/keptn-0.7.3.tgz)
 
 **Note:** If you have manually modified your Keptn deployment, e.g., you deleted the Kubernetes Secret `bridge-credentials` for disabling basic auth, the `keptn upgrade` command will not detect the modification. Please re-apply your modification after performing the upgrade.
 
@@ -61,7 +61,7 @@ To do so, please follow the instructions in the [backup guide](../../operate/bac
     * Please [verify that you are connected to the correct Kubernetes cluster](../../troubleshooting/#verify-kubernetes-context-with-keptn-installation)
 before executing this command.
     
-    * This CLI command executes a Helm upgrade using the Helm chart from [keptn-installer/keptn-0.7.2.tgz](https://storage.googleapis.com/keptn-installer/keptn-0.7.2.tgz).
+    * This CLI command executes a Helm upgrade using the Helm chart from [keptn-installer/keptn-0.7.2.tgz](https://charts.keptn.sh/packages/keptn-0.7.2.tgz).
 
 **Note:** If you have manually modified your Keptn deployment, e.g., you deleted the Kubernetes Secret `bridge-credentials` for disabling basic auth, the `keptn upgrade` command will not detect the modification. Please re-apply your modification after performing the upgrade.
 
@@ -77,7 +77,7 @@ To do so, please follow the instructions in the [backup guide](../../operate/bac
     * Please [verify that you are connected to the correct Kubernetes cluster](../../troubleshooting/#verify-kubernetes-context-with-keptn-installation)
 before executing this command.
     
-    * This CLI command executes a Helm upgrade using the Helm chart from [keptn-installer/keptn-0.7.1.tgz](https://storage.googleapis.com/keptn-installer/keptn-0.7.1.tgz).
+    * This CLI command executes a Helm upgrade using the Helm chart from [keptn-installer/keptn-0.7.1.tgz](https://charts.keptn.sh/packages/keptn-0.7.1.tgz).
 
 **Note:** If you have manually modified your Keptn deployment, e.g., you deleted the Kubernetes Secret `bridge-credentials` for disabling basic auth, the `keptn upgrade` command will not detect the modification. Please re-apply your modification after performing the upgrade.
 

--- a/content/docs/0.8.x/operate/advanced_install_options/index.md
+++ b/content/docs/0.8.x/operate/advanced_install_options/index.md
@@ -38,21 +38,21 @@ The following flags are available:
 ### Example: Use a LoadBalancer for api-gateway-nginx
 
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.8.7 --repo=https://storage.googleapis.com/keptn-installer --set=control-plane.apiGatewayNginx.type=LoadBalancer
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.8.7 --repo=https://charts.keptn.sh --set=control-plane.apiGatewayNginx.type=LoadBalancer
 ```
 
 ### Example: Install execution plane for Continuous Delivery use-case
 
 For example, the **Control Plane with the Execution Plane (for Continuous Delivery)** can be installed by the following command:
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.8.7 --repo=https://storage.googleapis.com/keptn-installer --set=continuous-delivery.enabled=true
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.8.7 --repo=https://charts.keptn.sh --set=continuous-delivery.enabled=true
 ```
 
 ### Example: Install execution plane for Continuous Delivery use-case and use a LoadBalancer for api-gateway-nginx
 
 For example, the **Control Plane with the Execution Plane (for Continuous Delivery)** and a `LoadBalancer` for exposing Keptn can be installed by the following command:
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.8.7 --repo=https://storage.googleapis.com/keptn-installer --set=continuous-delivery.enabled=true,control-plane.apiGatewayNginx.type=LoadBalancer
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.8.7 --repo=https://charts.keptn.sh --set=continuous-delivery.enabled=true,control-plane.apiGatewayNginx.type=LoadBalancer
 ```
 
 ### Example: Execute Helm upgrade without Internet connectivity
@@ -131,7 +131,7 @@ For example, if a user sets `control-plane.prefixPath=/mykeptn` in the Helm inst
 the Keptn API is located under `http://HOSTNAME/mykeptn/api` and the Keptn Bridge is located under `http://HOSTNAME/mykeptn/bridge`:
 
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.8.7 --repo=https://storage.googleapis.com/keptn-installer --set=control-plane.apiGatewayNginx.type=LoadBalancer,continuous-delivery.enabled=true,control-plane.prefixPath=/mykeptn
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.8.7 --repo=https://charts.keptn.sh --set=control-plane.apiGatewayNginx.type=LoadBalancer,continuous-delivery.enabled=true,control-plane.prefixPath=/mykeptn
 ```
 
 ### Example: Install Keptn with externally hosted MongoDB

--- a/content/docs/0.8.x/operate/upgrade/index.md
+++ b/content/docs/0.8.x/operate/upgrade/index.md
@@ -52,7 +52,7 @@ keptn upgrade
     * Please [verify that you are connected to the correct Kubernetes cluster](../../troubleshooting/#verify-kubernetes-context-with-keptn-installation)
 before executing this command.
 
-    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.8.7.tgz](https://storage.googleapis.com/keptn-installer/keptn-0.8.7.tgz)
+    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.8.7.tgz](https://charts.keptn.sh/packages/keptn-0.8.7.tgz)
 
 **Note:** If you have manually modified your Keptn deployment, e.g., you deleted the Kubernetes Secret `bridge-credentials` for disabling basic auth, the `keptn upgrade` command will not detect the modification. Please re-apply your modification after performing the upgrade.
 
@@ -98,7 +98,7 @@ keptn upgrade
     * Please [verify that you are connected to the correct Kubernetes cluster](../../troubleshooting/#verify-kubernetes-context-with-keptn-installation)
 before executing this command.
 
-    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.8.6.tgz](https://storage.googleapis.com/keptn-installer/keptn-0.8.6.tgz)
+    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.8.6.tgz](https://charts.keptn.sh/packages/keptn-0.8.6.tgz)
 
 **Note:** If you have manually modified your Keptn deployment, e.g., you deleted the Kubernetes Secret `bridge-credentials` for disabling basic auth, the `keptn upgrade` command will not detect the modification. Please re-apply your modification after performing the upgrade.
 
@@ -144,7 +144,7 @@ keptn upgrade
     * Please [verify that you are connected to the correct Kubernetes cluster](../../troubleshooting/#verify-kubernetes-context-with-keptn-installation)
 before executing this command.
 
-    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.8.5.tgz](https://storage.googleapis.com/keptn-installer/keptn-0.8.5.tgz)
+    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.8.5.tgz](https://charts.keptn.sh/packages/keptn-0.8.5.tgz)
 
 **Note:** If you have manually modified your Keptn deployment, e.g., you deleted the Kubernetes Secret `bridge-credentials` for disabling basic auth, the `keptn upgrade` command will not detect the modification. Please re-apply your modification after performing the upgrade.
 
@@ -191,7 +191,7 @@ keptn upgrade
     * Please [verify that you are connected to the correct Kubernetes cluster](../../troubleshooting/#verify-kubernetes-context-with-keptn-installation)
 before executing this command.
 
-    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.8.4.tgz](https://storage.googleapis.com/keptn-installer/keptn-0.8.4.tgz)
+    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.8.4.tgz](https://charts.keptn.sh/packages/keptn-0.8.4.tgz)
 
 **Note:** If you have manually modified your Keptn deployment, e.g., you deleted the Kubernetes Secret `bridge-credentials` for disabling basic auth, the `keptn upgrade` command will not detect the modification. Please re-apply your modification after performing the upgrade.
 
@@ -239,7 +239,7 @@ keptn upgrade
     * Please [verify that you are connected to the correct Kubernetes cluster](../../troubleshooting/#verify-kubernetes-context-with-keptn-installation)
 before executing this command.
     
-    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.8.3.tgz](https://storage.googleapis.com/keptn-installer/keptn-0.8.3.tgz)
+    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.8.3.tgz](https://charts.keptn.sh/packages/keptn-0.8.3.tgz)
 
 **Note:** If you have manually modified your Keptn deployment, e.g., you deleted the Kubernetes Secret `bridge-credentials` for disabling basic auth, the `keptn upgrade` command will not detect the modification. Please re-apply your modification after performing the upgrade.
 
@@ -317,7 +317,7 @@ keptn upgrade
     * Please [verify that you are connected to the correct Kubernetes cluster](../../troubleshooting/#verify-kubernetes-context-with-keptn-installation)
 before executing this command.
     
-    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.8.2.tgz](https://storage.googleapis.com/keptn-installer/keptn-0.8.2.tgz)
+    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.8.2.tgz](https://charts.keptn.sh/packages/keptn-0.8.2.tgz)
 
 **Note:** If you have manually modified your Keptn deployment, e.g., you deleted the Kubernetes Secret `bridge-credentials` for disabling basic auth, the `keptn upgrade` command will not detect the modification. Please re-apply your modification after performing the upgrade.
 
@@ -363,7 +363,7 @@ keptn upgrade
     * Please [verify that you are connected to the correct Kubernetes cluster](../../troubleshooting/#verify-kubernetes-context-with-keptn-installation)
 before executing this command.
     
-    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.8.1.tgz](https://storage.googleapis.com/keptn-installer/keptn-0.8.1.tgz)
+    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.8.1.tgz](https://charts.keptn.sh/packages/keptn-0.8.1.tgz)
 
 **Note:** If you have manually modified your Keptn deployment, e.g., you deleted the Kubernetes Secret `bridge-credentials` for disabling basic auth, the `keptn upgrade` command will not detect the modification. Please re-apply your modification after performing the upgrade.
 
@@ -412,7 +412,7 @@ Please follow the three steps to upgrade your Keptn 0.7.3 to 0.8.0.
     * Please [verify that you are connected to the correct Kubernetes cluster](../../troubleshooting/#verify-kubernetes-context-with-keptn-installation)
 before executing this command.
     
-    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.8.0.tgz](https://storage.googleapis.com/keptn-installer/keptn-0.8.0.tgz)
+    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.8.0.tgz](https://charts.keptn.sh/packages/keptn-0.8.0.tgz)
 
 **Note 1:** In Keptn 0.7.3 and before, evaluation results were of type `sh.keptn.events.evaluation-done` which has changed to `sh.keptn.event.evaluation.finished`. While the old type of event is still in the database and considered for calculating the quality gate score, the Bridge in version 0.8.0 does not display `sh.keptn.events.evaluation-done` events.
 

--- a/content/docs/0.9.x/operate/advanced_install_options/index.md
+++ b/content/docs/0.9.x/operate/advanced_install_options/index.md
@@ -54,21 +54,21 @@ The following flags are available:
 ### Example: Use a LoadBalancer for api-gateway-nginx
 
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.9.0 --repo=https://storage.googleapis.com/keptn-installer --set=control-plane.apiGatewayNginx.type=LoadBalancer
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.9.0 --repo=https://charts.keptn.sh --set=control-plane.apiGatewayNginx.type=LoadBalancer
 ```
 
 ### Example: Install execution plane for Continuous Delivery use-case
 
 For example, the **Control Plane with the Execution Plane (for Continuous Delivery)** can be installed by the following command:
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.9.0 --repo=https://storage.googleapis.com/keptn-installer --set=continuous-delivery.enabled=true
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.9.0 --repo=https://charts.keptn.sh --set=continuous-delivery.enabled=true
 ```
 
 ### Example: Install execution plane for Continuous Delivery use-case and use a LoadBalancer for api-gateway-nginx
 
 For example, the **Control Plane with the Execution Plane (for Continuous Delivery)** and a `LoadBalancer` for exposing Keptn can be installed by the following command:
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.9.0 --repo=https://storage.googleapis.com/keptn-installer --set=continuous-delivery.enabled=true,control-plane.apiGatewayNginx.type=LoadBalancer
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.9.0 --repo=https://charts.keptn.sh --set=continuous-delivery.enabled=true,control-plane.apiGatewayNginx.type=LoadBalancer
 ```
 
 ### Example: Execute Helm upgrade without Internet connectivity
@@ -147,7 +147,7 @@ For example, if a user sets `control-plane.prefixPath=/mykeptn` in the Helm inst
 the Keptn API is located under `http://HOSTNAME/mykeptn/api` and the Keptn Bridge is located under `http://HOSTNAME/mykeptn/bridge`:
 
 ```console
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.9.0 --repo=https://storage.googleapis.com/keptn-installer --set=control-plane.apiGatewayNginx.type=LoadBalancer,continuous-delivery.enabled=true,control-plane.prefixPath=/mykeptn
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.9.0 --repo=https://charts.keptn.sh --set=control-plane.apiGatewayNginx.type=LoadBalancer,continuous-delivery.enabled=true,control-plane.prefixPath=/mykeptn
 ```
 
 ### Example: Install Keptn with externally hosted MongoDB

--- a/content/docs/0.9.x/operate/upgrade/index.md
+++ b/content/docs/0.9.x/operate/upgrade/index.md
@@ -47,7 +47,7 @@ keptn upgrade
     * Please [verify that you are connected to the correct Kubernetes cluster](../../troubleshooting/#verify-kubernetes-context-with-keptn-installation)
 before executing this command.
 
-    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.9.2.tgz](https://storage.googleapis.com/keptn-installer/keptn-0.9.2.tgz)
+    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.9.2.tgz](https://charts.keptn.sh/packages/keptn-0.9.2.tgz)
 
 **Note:** If you have manually modified your Keptn deployment, e.g., you deleted the Kubernetes Secret `bridge-credentials` for disabling basic auth, the `keptn upgrade` command will not detect the modification. Please re-apply your modification after performing the upgrade.
 
@@ -95,7 +95,7 @@ keptn upgrade
     * Please [verify that you are connected to the correct Kubernetes cluster](../../troubleshooting/#verify-kubernetes-context-with-keptn-installation)
 before executing this command.
 
-    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.9.1.tgz](https://storage.googleapis.com/keptn-installer/keptn-0.9.1.tgz)
+    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.9.1.tgz](https://charts.keptn.sh/packages/keptn-0.9.1.tgz)
 
 **Note:** If you have manually modified your Keptn deployment, e.g., you deleted the Kubernetes Secret `bridge-credentials` for disabling basic auth, the `keptn upgrade` command will not detect the modification. Please re-apply your modification after performing the upgrade.
 
@@ -142,7 +142,7 @@ keptn upgrade
     * Please [verify that you are connected to the correct Kubernetes cluster](../../troubleshooting/#verify-kubernetes-context-with-keptn-installation)
 before executing this command.
 
-    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.9.0.tgz](https://storage.googleapis.com/keptn-installer/keptn-0.9.0.tgz)
+    * This CLI command executes a Helm upgrade using the Helm chart from: [keptn-installer/keptn-0.9.0.tgz](https://charts.keptn.sh/packages/keptn-0.9.0.tgz)
 
 **Note:** If you have manually modified your Keptn deployment, e.g., you deleted the Kubernetes Secret `bridge-credentials` for disabling basic auth, the `keptn upgrade` command will not detect the modification. Please re-apply your modification after performing the upgrade.
 

--- a/content/docs/concepts/architecture/index.md
+++ b/content/docs/concepts/architecture/index.md
@@ -10,8 +10,7 @@ Keptn is an event-based control plane for continuous delivery and automated oper
 {{< popup_image link="./assets/architecture.png" caption="Keptn architecture" width="65%">}}
 
 ## Prerequisites
-
-During a Keptn installation, [NATS](https://nats.io/) is installed in the Kubernetes namespace Keptn is running.
+During the installation of Keptn, [NATS](https://nats.io/) is installed into the Kubernetes namespace where Keptn is installed.
 
 ## Keptn CLI
 The Keptn CLI needs to be installed on the local machine and is used to send commands to Keptn by interacting with the API of Keptn. To communicate with Keptn you need to know a shared secret that is generated during the installation and verified by the *api* component.

--- a/content/docs/concepts/architecture/index.md
+++ b/content/docs/concepts/architecture/index.md
@@ -10,6 +10,7 @@ Keptn is an event-based control plane for continuous delivery and automated oper
 {{< popup_image link="./assets/architecture.png" caption="Keptn architecture" width="65%">}}
 
 ## Prerequisites
+
 During the installation of Keptn, [NATS](https://nats.io/) is installed into the Kubernetes namespace where Keptn is installed.
 
 ## Keptn CLI

--- a/content/docs/quickstart/_index.md
+++ b/content/docs/quickstart/_index.md
@@ -44,7 +44,7 @@ curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4
 2. **Download and install the [Keptn CLI](../0.11.x/reference/cli)**
 
     ```
-    curl -sL https://get.keptn.sh | KEPTN_VERSION=0.11.2 bash
+    curl -sL https://get.keptn.sh | KEPTN_VERSION=0.11.4 bash
     ```
 
 3. **Install Keptn** control-plane and execution-plane for continuous delivery use case or use the `helm install` version [mentioned below](#kubernetes-version-not-supported).
@@ -60,7 +60,7 @@ curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4
     <p>The installation logs will print the following output:
     <pre>
     Installing Keptn ...
-    Helm Chart used for Keptn installation: https://storage.googleapis.com/keptn-installer/keptn-0.11.2.tgz
+    Helm Chart used for Keptn installation: https://charts.keptn.sh/packages/keptn-0.11.4.tgz
     Start upgrading Helm Chart keptn in namespace keptn
     Finished upgrading Helm Chart keptn in namespace keptn
     Keptn control plane has been successfully set up on your cluster.
@@ -197,9 +197,9 @@ k3d cluster delete mykeptn
 In case `keptn install` prevents you from installing Keptn due to a (currently) unsupported Kubernetes version, you can bypass this check at your own risk by using the Helm installation option of Keptn.
 
 ```bash
-helm install keptn https://github.com/keptn/keptn/releases/download/0.11.2/keptn-0.11.2.tgz -n keptn --create-namespace --set=continuous-delivery.enabled=true --wait
-helm install helm-service https://github.com/keptn/keptn/releases/download/0.11.2/helm-service-0.11.2.tgz -n keptn --create-namespace --wait
-helm install jmeter-service https://github.com/keptn/keptn/releases/download/0.11.2/jmeter-service-0.11.2.tgz -n keptn --create-namespace --wait
+helm install keptn https://github.com/keptn/keptn/releases/download/0.11.4/keptn-0.11.4.tgz -n keptn --create-namespace --set=continuous-delivery.enabled=true --wait
+helm install helm-service https://github.com/keptn/keptn/releases/download/0.11.4/helm-service-0.11.4.tgz -n keptn --create-namespace --wait
+helm install jmeter-service https://github.com/keptn/keptn/releases/download/0.11.4/jmeter-service-0.11.4.tgz -n keptn --create-namespace --wait
 ```
 
 Now continue with step 4 from the quickstart guide.


### PR DESCRIPTION
### This PR
- changes all URLs pointing to the keptn helm charts to point to the new charts repository https://charts.keptn.sh
- fixes a sentence on the architecture page