### PR TITLE
Update of shipyard spec to: `spec.keptn.sh/0.2.3` for 0.10, 0.11, 0.12

### DIFF
--- a/content/docs/0.10.x/automated_operations/remediation/index.md
+++ b/content/docs/0.10.x/automated_operations/remediation/index.md
@@ -14,7 +14,7 @@ The definition of a remediation sequence is done in a so-called [Shipyard](../..
 
 **Example**: Simple shipyard file with a remediation sequence in a single stage
 ```yaml
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"

--- a/content/docs/0.10.x/continuous_delivery/multi_stage/index.md
+++ b/content/docs/0.10.x/continuous_delivery/multi_stage/index.md
@@ -12,7 +12,7 @@ The definition of a multi-stage delivery manifests in a so-called [Shipyard](../
 **Example**: Simple shipyard file with a delivery sequence in the two stages `dev` and `production`, whereas `dev` uses a direct deployment and `prod` uses blue-green deployment:
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -42,7 +42,7 @@ spec:
 **Example:** Extended shipyard with a delivery sequence in three stages `dev`, `hardening` and `production` in combination with tests:
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -91,7 +91,7 @@ spec:
 **Example:** Extended shipyard with two delivery sequence with varying deployment strategies (e.g., `delivery` is used for a Java-service, whereas `delivery-direct` is used for a database):
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"

--- a/content/docs/0.10.x/integrations/how_integrate/index.md
+++ b/content/docs/0.10.x/integrations/how_integrate/index.md
@@ -28,7 +28,7 @@ Usually, a testing tool integration is getting triggered upon a `sh.keptn.event.
 
 **Example shipyard** with a test task in each sequence:
 ```
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "test-shipyard"

--- a/content/docs/0.10.x/manage/project/index.md
+++ b/content/docs/0.10.x/manage/project/index.md
@@ -17,7 +17,7 @@ To create a project, you can use the CLI command [keptn create project](../../re
 
 The simplest shipyard.yaml file with a single stage and no sequences defined would look like this:
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"

--- a/content/docs/0.10.x/manage/shipyard/index.md
+++ b/content/docs/0.10.x/manage/shipyard/index.md
@@ -24,7 +24,7 @@ A stage is declared by its name. This name will be used for the branch in the Gi
 **Example of a shipyard with three stages:**
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -46,7 +46,7 @@ After defining stages, sequences can be added to a stage. A sequence is an order
 **Example:** Extended shipyard with a delivery sequence in all three stage:
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -133,7 +133,7 @@ Per default, an `automatic` approval strategy is used for evaluation result `pas
 <p>
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -248,7 +248,7 @@ Defines the test strategy used to validate a deployment. Keptn supports tests of
 <p>
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -299,7 +299,7 @@ If you want to add or remove an additional task to a sequence, you can do this b
 *Initial shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -324,7 +324,7 @@ spec:
 *Updated shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -354,7 +354,7 @@ If you want to add or remove an additional task sequence to a stage, you can do 
 *Initial shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -379,7 +379,7 @@ spec:
 *Updated shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -417,7 +417,7 @@ keptn trigger delivery --project=<project> --service=<service> --image=<image> -
 *Updated shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -477,7 +477,7 @@ sequences:
 *Initial shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -502,7 +502,7 @@ spec:
 *Updated shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"

--- a/content/docs/0.10.x/quality_gates/get_started/index.md
+++ b/content/docs/0.10.x/quality_gates/get_started/index.md
@@ -53,7 +53,7 @@ For the `easyBooking` application, the Keptn entities of a project, stage, and s
 For defining the stage(s) a service has to go through, a [Shipyard](../../manage/shipyard) file is needed. Since a quality gate should be configured for the *quality_assurance* environment only, the corresponding Shipyard for the *easyBooking* project looks as follows:
 
 ```yaml
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -68,7 +68,7 @@ spec:
 You do not have to define any task sequence in a stage because quality gates (aka. `evaluation`) are a built-in Keptn capability. Hence, there is no need to explicitly add an `evaluation` sequence. However, the explicit form of the above Shipyard file would look as the following one, which behaves the same way: 
 
 ```yaml
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"

--- a/content/docs/0.11.x/automated_operations/remediation/index.md
+++ b/content/docs/0.11.x/automated_operations/remediation/index.md
@@ -14,7 +14,7 @@ The definition of a remediation sequence is done in a so-called [Shipyard](../..
 
 **Example**: Simple shipyard file with a remediation sequence in a single stage
 ```yaml
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"

--- a/content/docs/0.11.x/continuous_delivery/multi_stage/index.md
+++ b/content/docs/0.11.x/continuous_delivery/multi_stage/index.md
@@ -12,7 +12,7 @@ The definition of a multi-stage delivery manifests in a so-called [Shipyard](../
 **Example**: Simple shipyard file with a delivery sequence in the two stages `dev` and `production`, whereas `dev` uses a direct deployment and `prod` uses blue-green deployment:
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -42,7 +42,7 @@ spec:
 **Example:** Extended shipyard with a delivery sequence in three stages `dev`, `hardening` and `production` in combination with tests:
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -91,7 +91,7 @@ spec:
 **Example:** Extended shipyard with two delivery sequence with varying deployment strategies (e.g., `delivery` is used for a Java-service, whereas `delivery-direct` is used for a database):
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"

--- a/content/docs/0.11.x/integrations/how_integrate/index.md
+++ b/content/docs/0.11.x/integrations/how_integrate/index.md
@@ -28,7 +28,7 @@ Usually, a testing tool integration is getting triggered upon a `sh.keptn.event.
 
 **Example shipyard** with a test task in each sequence:
 ```
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "test-shipyard"

--- a/content/docs/0.11.x/manage/project/index.md
+++ b/content/docs/0.11.x/manage/project/index.md
@@ -17,7 +17,7 @@ To create a project, you can use the CLI command [keptn create project](../../re
 
 The simplest shipyard.yaml file with a single stage and no sequences defined would look like this:
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"

--- a/content/docs/0.11.x/manage/shipyard/index.md
+++ b/content/docs/0.11.x/manage/shipyard/index.md
@@ -24,7 +24,7 @@ A stage is declared by its name. This name will be used for the branch in the Gi
 **Example of a shipyard with three stages:**
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -46,7 +46,7 @@ After defining stages, sequences can be added to a stage. A sequence is an order
 **Example:** Extended shipyard with a delivery sequence in all three stage:
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -135,7 +135,7 @@ Per default, an `automatic` approval strategy is used for evaluation result `pas
 <p>
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -250,7 +250,7 @@ Defines the test strategy used to validate a deployment. Keptn supports tests of
 <p>
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -301,7 +301,7 @@ If you want to add or remove an additional task to a sequence, you can do this b
 *Initial shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -326,7 +326,7 @@ spec:
 *Updated shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -356,7 +356,7 @@ If you want to add or remove an additional task sequence to a stage, you can do 
 *Initial shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -381,7 +381,7 @@ spec:
 *Updated shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -419,7 +419,7 @@ keptn trigger delivery --project=<project> --service=<service> --image=<image> -
 *Updated shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -479,7 +479,7 @@ sequences:
 *Initial shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -504,7 +504,7 @@ spec:
 *Updated shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"

--- a/content/docs/0.11.x/quality_gates/get_started/index.md
+++ b/content/docs/0.11.x/quality_gates/get_started/index.md
@@ -53,7 +53,7 @@ For the `easyBooking` application, the Keptn entities of a project, stage, and s
 For defining the stage(s) a service has to go through, a [Shipyard](../../manage/shipyard) file is needed. Since a quality gate should be configured for the *quality_assurance* environment only, the corresponding Shipyard for the *easyBooking* project looks as follows:
 
 ```yaml
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -68,7 +68,7 @@ spec:
 You do not have to define any task sequence in a stage because quality gates (aka. `evaluation`) are a built-in Keptn capability. Hence, there is no need to explicitly add an `evaluation` sequence. However, the explicit form of the above Shipyard file would look as the following one, which behaves the same way: 
 
 ```yaml
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"

--- a/content/docs/0.12.x/automated_operations/remediation/index.md
+++ b/content/docs/0.12.x/automated_operations/remediation/index.md
@@ -14,7 +14,7 @@ The definition of a remediation sequence is done in a so-called [Shipyard](../..
 
 **Example**: Simple shipyard file with a remediation sequence in a single stage
 ```yaml
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"

--- a/content/docs/0.12.x/continuous_delivery/multi_stage/index.md
+++ b/content/docs/0.12.x/continuous_delivery/multi_stage/index.md
@@ -12,7 +12,7 @@ The definition of a multi-stage delivery manifests in a so-called [Shipyard](../
 **Example**: Simple shipyard file with a delivery sequence in the two stages `dev` and `production`, whereas `dev` uses a direct deployment and `prod` uses blue-green deployment:
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -42,7 +42,7 @@ spec:
 **Example:** Extended shipyard with a delivery sequence in three stages `dev`, `hardening` and `production` in combination with tests:
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -91,7 +91,7 @@ spec:
 **Example:** Extended shipyard with two delivery sequence with varying deployment strategies (e.g., `delivery` is used for a Java-service, whereas `delivery-direct` is used for a database):
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"

--- a/content/docs/0.12.x/integrations/how_integrate/index.md
+++ b/content/docs/0.12.x/integrations/how_integrate/index.md
@@ -28,7 +28,7 @@ Usually, a testing tool integration is getting triggered upon a `sh.keptn.event.
 
 **Example shipyard** with a test task in each sequence:
 ```
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "test-shipyard"

--- a/content/docs/0.12.x/manage/project/index.md
+++ b/content/docs/0.12.x/manage/project/index.md
@@ -17,7 +17,7 @@ To create a project, you can use the CLI command [keptn create project](../../re
 
 The simplest shipyard.yaml file with a single stage and no sequences defined would look like this:
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"

--- a/content/docs/0.12.x/manage/shipyard/index.md
+++ b/content/docs/0.12.x/manage/shipyard/index.md
@@ -24,7 +24,7 @@ A stage is declared by its name. This name will be used for the branch in the Gi
 **Example of a shipyard with three stages:**
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -46,7 +46,7 @@ After defining stages, sequences can be added to a stage. A sequence is an order
 **Example:** Extended shipyard with a delivery sequence in all three stage:
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -135,7 +135,7 @@ Per default, an `automatic` approval strategy is used for evaluation result `pas
 <p>
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -250,7 +250,7 @@ Defines the test strategy used to validate a deployment. Keptn supports tests of
 <p>
 
 ```yaml
-apiVersion: spec.keptn.sh/0.2.2
+apiVersion: spec.keptn.sh/0.2.3
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -301,7 +301,7 @@ If you want to add or remove an additional task to a sequence, you can do this b
 *Initial shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -326,7 +326,7 @@ spec:
 *Updated shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -356,7 +356,7 @@ If you want to add or remove an additional task sequence to a stage, you can do 
 *Initial shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -381,7 +381,7 @@ spec:
 *Updated shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -419,7 +419,7 @@ keptn trigger delivery --project=<project> --service=<service> --image=<image> -
 *Updated shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -479,7 +479,7 @@ sequences:
 *Initial shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -504,7 +504,7 @@ spec:
 *Updated shipyard:*
 
 ```
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"

--- a/content/docs/0.12.x/quality_gates/get_started/index.md
+++ b/content/docs/0.12.x/quality_gates/get_started/index.md
@@ -53,7 +53,7 @@ For the `easyBooking` application, the Keptn entities of a project, stage, and s
 For defining the stage(s) a service has to go through, a [Shipyard](../../manage/shipyard) file is needed. Since a quality gate should be configured for the *quality_assurance* environment only, the corresponding Shipyard for the *easyBooking* project looks as follows:
 
 ```yaml
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"
@@ -68,7 +68,7 @@ spec:
 You do not have to define any task sequence in a stage because quality gates (aka. `evaluation`) are a built-in Keptn capability. Hence, there is no need to explicitly add an `evaluation` sequence. However, the explicit form of the above Shipyard file would look as the following one, which behaves the same way: 
 
 ```yaml
-apiVersion: "spec.keptn.sh/0.2.2"
+apiVersion: "spec.keptn.sh/0.2.3"
 kind: "Shipyard"
 metadata:
   name: "shipyard-sockshop"


### PR DESCRIPTION
Signed-off-by: Johannes <johannes.braeuer@dynatrace.com>

Since Keptn 0.10, the spec.keptn.sh version of Shipyard is: `spec.keptn.sh/0.2.3` (see: https://github.com/keptn/keptn/releases/tag/0.10.0). Consequently, I updated it to be correct.