### PR TITLE
fix: remove link to calendly

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -26,7 +26,6 @@
           <li><a href="https://github.com/keptn/keptn/releases/" class="footer-link">Releases</a></li>
           <li><a href="https://github.com/keptn/keptn/issues" class="footer-link">Issues</a></li>
           <li><a href="https://slack.keptn.sh" class="footer-link">Slack</a></li>
-          <li><a href="https://calendly.com/jetzlstorfer/keptn" class="footer-link">Talk to an expert</a></li>
         </ul>
       </div>
       <div class="col-md-2 pt-3 pt-md-0">


### PR DESCRIPTION
Signed-off-by: Juergen Etzlstorfer <jetzlstorfer@microsoft.com>

Removes the link to my outdated calendly. can be seen as a temporary fix until a new calendly link can be provided.

fixes #1014 