### PR TITLE
fix: dynatrace-service requires scoped secrets since 0.18

### DIFF
--- a/content/docs/0.10.x/monitoring/dynatrace/install/index.md
+++ b/content/docs/0.10.x/monitoring/dynatrace/install/index.md
@@ -66,6 +66,12 @@ To function correctly, the *dynatrace-service* requires access to a Dynatrace te
    keptn create secret dynatrace --from-literal="DT_TENANT=$DT_TENANT" --from-literal="DT_API_TOKEN=$DT_API_TOKEN"
     ```
 
+*Note*: For dynatrace-service version 0.18 or newer, the flag `--scope="dynatrace-service"` is required:
+
+    ```console
+    keptn create secret dynatrace --scope="dynatrace-service" --from-literal="DT_TENANT=$DT_TENANT" --from-literal="DT_API_TOKEN=$DT_API_TOKEN"
+    ```
+
 ### 3. Gather Keptn credentials
 
 The *dynatrace-service* also requires access to the Keptn API, provided through the `KEPTN_API_URL`, `KEPTN_API_TOKEN` and optionally `KEPTN_BRIDGE_URL`:

--- a/content/docs/0.10.x/monitoring/dynatrace/install/index.md
+++ b/content/docs/0.10.x/monitoring/dynatrace/install/index.md
@@ -69,7 +69,7 @@ To function correctly, the *dynatrace-service* requires access to a Dynatrace te
 *Note*: For dynatrace-service version 0.18 or newer, the flag `--scope="dynatrace-service"` is required:
 
     ```console
-    keptn create secret dynatrace --scope="dynatrace-service" --from-literal="DT_TENANT=$DT_TENANT" --from-literal="DT_API_TOKEN=$DT_API_TOKEN"
+   keptn create secret dynatrace --scope="dynatrace-service" --from-literal="DT_TENANT=$DT_TENANT" --from-literal="DT_API_TOKEN=$DT_API_TOKEN"
     ```
 
 ### 3. Gather Keptn credentials

--- a/content/docs/0.11.x/monitoring/dynatrace/install/index.md
+++ b/content/docs/0.11.x/monitoring/dynatrace/install/index.md
@@ -63,8 +63,11 @@ To function correctly, the *dynatrace-service* requires access to a Dynatrace te
 * Create a secret (named `dynatrace` by default) containing the credentials for the Dynatrace Tenant (`DT_API_TOKEN` and `DT_TENANT`).
 
     ```console
-   keptn create secret dynatrace --from-literal="DT_TENANT=$DT_TENANT" --from-literal="DT_API_TOKEN=$DT_API_TOKEN"
+    keptn create secret dynatrace --scope="dynatrace-service" --from-literal="DT_TENANT=$DT_TENANT" --from-literal="DT_API_TOKEN=$DT_API_TOKEN"
     ```
+
+*Note*: For dynatrace-service version 0.17 and older, please omit the flag `--scope="dynatrace-service"`.
+
 
 ### 3. Gather Keptn credentials
 

--- a/content/docs/0.12.x/monitoring/dynatrace/install/index.md
+++ b/content/docs/0.12.x/monitoring/dynatrace/install/index.md
@@ -63,7 +63,7 @@ To function correctly, the *dynatrace-service* requires access to a Dynatrace te
 * Create a secret (named `dynatrace` by default) containing the credentials for the Dynatrace Tenant (`DT_API_TOKEN` and `DT_TENANT`).
 
     ```console
-   keptn create secret dynatrace --from-literal="DT_TENANT=$DT_TENANT" --from-literal="DT_API_TOKEN=$DT_API_TOKEN"
+    keptn create secret dynatrace --scope="dynatrace-service" --from-literal="DT_TENANT=$DT_TENANT" --from-literal="DT_API_TOKEN=$DT_API_TOKEN"
     ```
 
 ### 3. Gather Keptn credentials


### PR DESCRIPTION
According to https://github.com/keptn-contrib/dynatrace-service/blob/master/documentation/project-setup.md#create-a-secret-with-keptn-cli, creating a new secret for dynatrace-service requires a scope="dynatrace-service" flag since dynatrace-service 0.18.

I've adapted this for Keptn 0.10, 0.11 and 0.12:

* for 0.10, I made it optional with a note to add it for newer versions of dynatrace-service [Preview 0.10](https://deploy-preview-1022--keptn.netlify.app/docs/0.10.x/monitoring/dynatrace/install/#2-create-a-secret-with-credentials)
* for 0.11, I made it the default, leaving a note that older versions don't need this [Preview 0.11](https://deploy-preview-1022--keptn.netlify.app/docs/0.11.x/monitoring/dynatrace/install/#2-create-a-secret-with-credentials)
* for 0.12, I made it required to use the flag (assuming that someone with Keptn 0.12 will already run something newer than dynatrace-service 0.18) [Preview 0.12](https://deploy-preview-1022--keptn.netlify.app/docs/0.12.x/monitoring/dynatrace/install/#2-create-a-secret-with-credentials)


