### PR TITLE
Fix: upgrade instructions for Keptn 0.12 referred to 0.12

### DIFF
--- a/content/docs/0.12.x/operate/upgrade/index.md
+++ b/content/docs/0.12.x/operate/upgrade/index.md
@@ -33,7 +33,7 @@ aliases:
       keptn version
       ```
 
-* **Step 2.** To upgrade your Keptn installation from 0.12.x to 0.12.0, the Keptn CLI offers the command:
+* **Step 2.** To upgrade your Keptn installation from 0.11.x to 0.12.0, the Keptn CLI offers the command:
   
    ```console
    keptn upgrade


### PR DESCRIPTION
Upgrade instructions for Keptn 0.12 referred to 0.12.x, which should have been 0.11.x.