### PR TITLE
Hide Release 0.9.x and 0.10.x in the docs

### DIFF
--- a/content/docs/0.10.x/_index.md
+++ b/content/docs/0.10.x/_index.md
@@ -4,6 +4,7 @@ linktitle: Release 0.10.0
 weight: 986
 sidebar_multicard: true
 icon: docs
+hide: true
 unsupported: This documentation is for an older Keptn release. Please consider the newest one when working with the latest Keptn.
 aliases:
   - /docs/0.10.0/

--- a/content/docs/0.9.x/_index.md
+++ b/content/docs/0.9.x/_index.md
@@ -4,6 +4,7 @@ linktitle: Release 0.9.2
 weight: 986
 sidebar_multicard: true
 icon: docs
+hide: true
 unsupported: This documentation is for an older Keptn release. Please consider the newest one when working with the latest Keptn.
 aliases:
   - /docs/0.9.0/


### PR DESCRIPTION
This PR hides the release documentation for `0.9.x` and `0.10.x` from the menu. The content is still available and accessible via a link to `https://keptn.sh/docs/0.9.x/` and `https://keptn.sh/docs/0.10.x/`

Signed-off-by: Johannes <johannes.braeuer@dynatrace.com>