### PR TITLE
Add redirect to the GSoC website

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,6 @@ HUGO_ENABLEGITINFO = "true"
 [[redirects]]
   from = "/gsoc"
   to = "https://github.com/keptn/community/blob/main/mentorship/gsoc"
-  status = 301
+  status = 302
   force = false
   query = {path = ":path"}

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,3 +8,10 @@ command = "hugo -b $DEPLOY_PRIME_URL"
 HUGO_VERSION = "0.53"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
+
+[[redirects]]
+  from = "/gsoc"
+  to = "https://github.com/keptn/community/blob/main/mentorship/gsoc"
+  status = 301
+  force = false
+  query = {path = ":path"}


### PR DESCRIPTION
Redirects keptn.sh/gsoc to https://github.com/keptn/community/blob/main/mentorship/gsoc where all the content resides at the moment

Signed-off-by: Oleg Nenashev <o.v.nenashev@gmail.com>