### PR TITLE
feat: Added Webhook filter to integrations page

### DIFF
--- a/content/docs/integrations/_index.md
+++ b/content/docs/integrations/_index.md
@@ -17,6 +17,7 @@ In the following you'll find integrations that are already provided by the Keptn
 <button class="btn filterBtn" value="testing">Testing</button>
 <button class="btn filterBtn" value="deployment">Deployment</button>
 <button class="btn filterBtn" value="observability">Observability</button>
+<button class="btn filterBtn" value="webhook">Webhook</button>
 
 <script type="text/javascript">
     const input = document.getElementById("services-search");


### PR DESCRIPTION
Currently filtering is done by using the `ts_query_web`, which filters using a full text search. I just asked the Artifacthub team if it's also possible to filter by annotations like `keptn/kind` or `keptn/version`. If this is possible I'll update the code appropriately.

Preview: https://deploy-preview-1075--keptn.netlify.app/docs/integrations/

![image](https://user-images.githubusercontent.com/56065213/156995708-1c3b9aa5-db95-4b3d-8530-a260e730b663.png)

Fixes #1036 