### PR TITLE
Fixed "backup" vs "back up" in Backup & Restore page

### DIFF
--- a/content/docs/0.13.x/operate/backup_and_restore/index.md
+++ b/content/docs/0.13.x/operate/backup_and_restore/index.md
@@ -1,23 +1,23 @@
 ---
-title: Backup and restore Keptn
-description: How to backup and restore Keptn.
+title: Back up and restore Keptn
+description: How to back up and restore Keptn.
 weight: 50
-keywords: backup
+keywords: back up
 ---
 
 To secure all your data in your projects' Git repository, as well as all events that have occurred for these projects, you need to 
-backup the data within the *Configuration Service*, the *MongoDB*, and credentials to your projects' Git upstream repos (if you have configured those).
+back up the data within the *Configuration Service*, the *MongoDB*, and credentials to your projects' Git upstream repos (if you have configured those).
 The following sections describe how to back up that data and how to restore it.
 
 **Note:** These instructions do not cover backing up any Helm- or Istio-related configurations.
 
 :warning: Please make sure your `kubectl` is connected to the cluster where Keptn is running. 
 
-## Backup Keptn
+## Back up Keptn
 
-This section describes how to backup your Keptn and store it on your local machine. 
+This section describes how to back up your Keptn and store it on your local machine. 
 
-### Backup Configuration Service
+### Back up Configuration Service
 
 First, create a local backup directory containing all data within the Git repos of the configuration-service. To do so, please execute the following command:
 
@@ -37,7 +37,7 @@ $ ls config-svc-backup/config
 lost+found	sockshop my-project
 ```
 
-### Backup Mongodb Data
+### Back up Mongodb Data
 
 The next step is to create a backup of the mongodb database in the `keptn-datastore` namespace using the `mongodump` tool.`
 
@@ -60,9 +60,9 @@ MONGODB_POD=$(kubectl get pods -n keptn -lapp.kubernetes.io/name=mongo -ojsonpat
 kubectl cp keptn/$MONGODB_POD:/tmp/dump ./mongodb-backup/ -c mongodb
 ```
 
-### Backup Git credentials
+### Back up Git credentials
 
-For projects where you have configured a Git upstream repository, we advise you to backup the Kubernetes secrets needed to access those.
+For projects where you have configured a Git upstream repository, we advise you to back up the Kubernetes secrets needed to access those.
 To do so, please execute the following command for each project for which you have configured an upstream repo:
 
 ```console

--- a/content/docs/0.13.x/operate/backup_and_restore/index.md
+++ b/content/docs/0.13.x/operate/backup_and_restore/index.md
@@ -2,7 +2,7 @@
 title: Back up and restore Keptn
 description: How to back up and restore Keptn.
 weight: 50
-keywords: back up
+keywords: backup
 ---
 
 To secure all your data in your projects' Git repository, as well as all events that have occurred for these projects, you need to 


### PR DESCRIPTION
Fixed the correct use of Back up (verb) and Backup (adjective) in the file `Backup_and_restore` Markdown page