### PR TITLE
Rewrote intro to Quick Start

### DIFF
--- a/content/docs/quickstart/_index.md
+++ b/content/docs/quickstart/_index.md
@@ -8,8 +8,8 @@ hidechildren: true # this flag hides all sub-pages in the sidebar-multicard.html
 ---
 
 This Quick Start guide shows how to quickly create a local Keptn installation
-that runs either as a [Helm](#helm) chart
-or as a [Docker](#keptn-hello-world-docker-based) container
+that runs either as a [Helm](#helm) chart in Kubernetes
+or as [Docker](#keptn-hello-world-docker-based) container in K3d
 and run some exercises to demonstrate Keptn functionality.
 
 You can install and run Keptn on virtually any Kubernetes cluster.

--- a/content/docs/quickstart/_index.md
+++ b/content/docs/quickstart/_index.md
@@ -7,7 +7,14 @@ weight: 1
 hidechildren: true # this flag hides all sub-pages in the sidebar-multicard.html
 ---
 
-Pick your favourite installation method: [Helm](#helm), [Docker](#keptn-hello-world-docker-based), [Keptn CLI](#keptn-cli) or [k3d](#k3d-keptn).
+This Quick Start guide shows how to quickly create a local Keptn installation
+that runs either as a [Helm](#helm) chart
+or as a [Docker](#keptn-hello-world-docker-based) container
+and run some exercises to demonstrate Keptn functionality.
+
+You can install and run Keptn on virtually any Kubernetes cluster.
+See Install CLI and Keptn for detailed instructions
+about creating a Keptn cluster locally or in the cloud.
 
 ## Helm
 


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

Rewrote intro to Quick Start.  Am pushing this alone so it can be reconciled with what Meha Bhalodiya is doing.

@agardnerIT convinced me that the Quick Start should just show the Helm chart and Docker options  and we put all of the manual installation instructions into the Install docs but I will do that in a separate PR.  I want to compare what is in Quick Start with what is currently in the Install docs and be sure that we end up with the best information when we're done.  For now, just imagine that material gone from the Quick Start.