### PR TITLE
feat: add troubleshooting guide for monitoring dynatrace

### DIFF
--- a/content/docs/0.11.x/monitoring/dynatrace/troubleshooting/index.md
+++ b/content/docs/0.11.x/monitoring/dynatrace/troubleshooting/index.md
@@ -1,0 +1,10 @@
+---
+title: Troubleshooting
+description: Find solutions to problems when working with Dynatrace Keptn integration
+weight: 6
+icon: docs
+---
+
+## Documentation at Dynatrace Keptn integration
+
+Find the troubleshooting guide at the [repository of the Dynatrace Keptn integration](https://github.com/keptn-contrib/dynatrace-service/blob/master/documentation/troubleshooting.md).

--- a/content/docs/0.12.x/monitoring/dynatrace/troubleshooting/index.md
+++ b/content/docs/0.12.x/monitoring/dynatrace/troubleshooting/index.md
@@ -1,0 +1,10 @@
+---
+title: Troubleshooting
+description: Find solutions to problems when working with Dynatrace Keptn integration
+weight: 6
+icon: docs
+---
+
+## Documentation at Dynatrace Keptn integration
+
+Find the troubleshooting guide at the [repository of the Dynatrace Keptn integration](https://github.com/keptn-contrib/dynatrace-service/blob/master/documentation/troubleshooting.md).

--- a/content/docs/0.13.x/monitoring/dynatrace/troubleshooting/index.md
+++ b/content/docs/0.13.x/monitoring/dynatrace/troubleshooting/index.md
@@ -1,0 +1,10 @@
+---
+title: Troubleshooting
+description: Find solutions to problems when working with Dynatrace Keptn integration
+weight: 6
+icon: docs
+---
+
+## Documentation at Dynatrace Keptn integration
+
+Find the troubleshooting guide at the [repository of the Dynatrace Keptn integration](https://github.com/keptn-contrib/dynatrace-service/blob/master/documentation/troubleshooting.md).

--- a/content/docs/0.14.x/monitoring/dynatrace/troubleshooting/index.md
+++ b/content/docs/0.14.x/monitoring/dynatrace/troubleshooting/index.md
@@ -1,0 +1,10 @@
+---
+title: Troubleshooting
+description: Find solutions to problems when working with Dynatrace Keptn integration
+weight: 6
+icon: docs
+---
+
+## Documentation at Dynatrace Keptn integration
+
+Find the troubleshooting guide at the [repository of the Dynatrace Keptn integration](https://github.com/keptn-contrib/dynatrace-service/blob/master/documentation/troubleshooting.md).


### PR DESCRIPTION
This PR adds a single section to `monitoring/dynatrace` for versions `0.11.x`, `0.12.x`, `0.13.x` and `0.14.x` with a link to the troubleshooting guide at [dynatrace-service](https://github.com/keptn-contrib/dynatrace-service)