### PR TITLE
Update of helm upgrade command in Keptn 0.14. upgrade guide

### DIFF
--- a/content/docs/0.14.x/operate/upgrade/index.md
+++ b/content/docs/0.14.x/operate/upgrade/index.md
@@ -54,7 +54,8 @@ Please, refer to the [distributor documentation](https://github.com/keptn/keptn/
    * If the CLI still complains about the context, please use the Helm approach to upgrade your cluster:
 
    ```console
-   helm upgrade keptn keptn --install -n keptn --create-namespace --repo=https://charts.keptn.sh --version=0.14.1 --reuse-values --wait
+   helm get values keptn -n keptn > MY_VALUES.yaml
+   helm upgrade keptn keptn --install -n keptn --create-namespace --repo=https://charts.keptn.sh --version=0.14.1 --wait --values=MY_VALUES.yaml
    ```
 
 * :warning: **Step 3.** If you are using the **jmeter-service** or **helm-service**, upgrade them to 0.14.1 using the following commands:


### PR DESCRIPTION
Changed the `helm upgrade` command to use `--values` flag instead of `--reuse-values`.

Signed-off-by: Johannes <johannes.braeuer@dynatrace.com>