### PR TITLE
Modified weights for top-level sections

### DIFF
--- a/content/docs/concepts/_index.md
+++ b/content/docs/concepts/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Concepts
 description: Learn about the core concepts, use-cases, and architecture of Keptn.
-weight: 2
+weight: 20
 icon: concepts
 ---

--- a/content/docs/quickstart/_index.md
+++ b/content/docs/quickstart/_index.md
@@ -3,7 +3,7 @@ title: Quick Start
 description: Learn how to get Keptn running in five minutes. Whether you prefer Helm, Docker or Keptn CLI, or k3d, we have you covered.
 icon: concepts
 layout: quickstart
-weight: 1
+weight: 10
 hidechildren: true # this flag hides all sub-pages in the sidebar-multicard.html
 ---
 

--- a/content/docs/roadmap/_index.md
+++ b/content/docs/roadmap/_index.md
@@ -3,7 +3,7 @@ title: Roadmap
 description: Find the Keptn Roadmap here
 icon: concepts
 layout: quickstart
-weight: 3
+weight: 90
 hidechildren: true # this flag hides all sub pages in the sidebar-multicard.html
 ---
 

--- a/content/docs/tutorials/_index.md
+++ b/content/docs/tutorials/_index.md
@@ -2,7 +2,7 @@
 title: Tutorials
 icon: tasks
 layout: tutorials
-weight: 4
+weight: 40
 hidechildren: true # this flag hides all sub pages in the sidebar-multicard.html
 ---
 


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

The Quick Start, Concepts, Roadmap, and Tutorials sections had weights of 1, 2, 3, and 4 so no way to interpolate other sections between them.  This changes those weights to 10, 20, 30, and 40 to allow for some expansion.