### PR TITLE
fix typo from 13 to 14

### DIFF
--- a/content/docs/0.14.x/operate/advanced_install_options/index.md
+++ b/content/docs/0.14.x/operate/advanced_install_options/index.md
@@ -63,7 +63,7 @@ The following artifacts need to be available locally:
 
 **Download Keptn Helm Charts**
 
-Download the Helm charts from the [Keptn 0.13.0 release](https://github.com/keptn/keptn/releases/tag/0.14.1):
+Download the Helm charts from the [Keptn 0.14.1 release](https://github.com/keptn/keptn/releases/tag/0.14.1):
 
 * Keptn Control Plane: https://github.com/keptn/keptn/releases/download/0.14.1/keptn-0.14.1.tgz
 * helm-service (if needed): https://github.com/keptn/keptn/releases/download/0.14.1/helm-service-0.14.1.tgz


### PR DESCRIPTION
Fix a small typo on the 0.14.1 advanced install page. A hyperlink mentioned v0.13 when it should be called `0.14.1`

Ironically there's a typo in the branch name: `type` should be `typo` :)

Signed-off-by: adamgardnerit <adam@agardner.net>