### PR TITLE
add shipyard ref, manage triggers, modify manage shipyard

### DIFF
--- a/content/docs/0.16.x/manage/shipyard/index.md
+++ b/content/docs/0.16.x/manage/shipyard/index.md
@@ -2,7 +2,7 @@
 title: Working with shipyard files
 description: Information about shipyard, sequences and tasks to define processes and workflows.
 weight: 25
-keywords: [0.15.x-manage]
+keywords: [0.16.x-manage]
 aliases:
 ---
 
@@ -51,8 +51,7 @@ This means that all services in a project share the same shipyard definition.
             - name: "deployment"
             - name: "release"
 
-        - name: "production"
-          sequences:
+
           - name: "delivery"
             triggeredOn:
               - event: "hardening.delivery.finished"

--- a/content/docs/0.16.x/manage/shipyard/index.md
+++ b/content/docs/0.16.x/manage/shipyard/index.md
@@ -1,290 +1,103 @@
 ---
-title: Shipyard
+title: Working with shipyard files
 description: Information about shipyard, sequences and tasks to define processes and workflows.
 weight: 25
-keywords: [0.16.x-manage]
+keywords: [0.15.x-manage]
 aliases:
 ---
 
-## Declare Shipyard (before creating a project)
-
-* A shipyard is defined at the level of a project. This means that all services in a project share the same shipyard definition.
+A [shipyard.yaml](../../reference/files/shipyard) file is defined at the level of a project.
+This means that all services in a project share the same shipyard definition.
 
 * A shipyard defines the stages each deployment has to go through until it is released in the final stage, e.g., the production stage.
 
-* A shipyard can consist of any number of stages; but at least one. A stage must have at least the name property.
+* A shipyard can consist of any number of stages; but at least one. Each stage must have at least the name property.
 
-* A stage can consist of any number of sequences; but at least one.
-
-
-### Definition of Stage
-
-A stage is declared by its name. This name is used for the branch in the Git repository and Kubernetes namespace to which services at this stage will be deployed.
+* A stage can contain any number of sequences but must have at least one.
 
 **Example of a shipyard with three stages:**
 
-```yaml
-apiVersion: spec.keptn.sh/0.2.3
-kind: "Shipyard"
-metadata:
-  name: "shipyard-sockshop"
-spec:
-  stages:
-    - name: "dev"
-    - name: "hardening"
-    - name: "production"
-```
-
-### Definition of Sequence in a Stage
-
-After defining stages, sequences can be added to a stage. A sequence is an ordered list of tasks that are triggered sequentially. A `sequence` consists of the following properties:
-
-* `name`: A unique name of the sequence
-* `triggeredOn` (optional): An array of events that trigger the sequence.
-* `tasks`: An array of tasks executed by the sequence in the declared order.
+    apiVersion: spec.keptn.sh/0.2.3
+    kind: "Shipyard"
+    metadata:
+      name: "shipyard-sockshop"
+    spec:
+      stages:
+        - name: "dev"
+        - name: "hardening"
+        - name: "production"
 
 **Example:** Extended shipyard with a delivery sequence in all three stage:
 
-```yaml
-apiVersion: spec.keptn.sh/0.2.3
-kind: "Shipyard"
-metadata:
-  name: "shipyard-sockshop"
-spec:
-  stages:
-    - name: "dev"
-      sequences:
-      - name: "delivery"
-        tasks: 
-        - name: "deployment"
-        - name: "release"
-
-    - name: "hardening"
-      sequences:
-      - name: "delivery"
-        triggeredOn:
-          - event: "dev.delivery.finished"
-        tasks: 
-        - name: "deployment"
-        - name: "release"
-
-    - name: "production"
-      sequences:
-      - name: "delivery"
-        triggeredOn:
-          - event: "hardening.delivery.finished"
-        tasks: 
-        - name: "deployment"
-        - name: "release"
-```
-
-### Reserved Keptn Tasks
-
-Keptn supports a set of opinionated tasks for declaring a delivery or remediation sequence:
-
-* action
-* approval
-* deployment
-* evaluation
-* get-action
-* release
-* rollback
-* test
-
-#### Action
-
-The action task indicates that a remediation action should be executed by an action provider. It is used within a [remediation workflow](../../automated_operations/remediation).
-
-**Usage:**
-
-```
-- name: action
-```
-
-#### Approval
-
-The approval task intercepts the task sequence and waits for a user to approve or decline the open approval. This task can be added, for example, before deploying an artifact into the next stage. The approval strategy can be defined based on the evaluation result `pass` and `warning`. Keptn supports the following approval strategies for the evaluation results `pass` and `warning`:
-
-* `automatic`: The artifact is deployed automatically.
-* `manual`: The user is asked for approval before triggering the deployment.
-
-This allows combinations as follows:
-
-|                          | Evaluation result: pass           | Evaluation result: warning                 | Behavior  |
-|--------------------------|-----------------------------------|--------------------------------------------|-----------|
-| **Skip approval task:** | pass:automatic | warning:automatic | Regardless of the evaluation result, the approval task is skipped |
-| **Depending on evaluation result:**   | pass:automatic | warning:manual    | If the evaluation result is a **warning**, an approval is required |
-| **Depending on evaluation result:**   | pass:manual    | warning:automatic | If the evaluation result is a **pass**, an approval is required |
-| **Mandatory approval task:**          | pass:manual    | warning:manual    | Regardless of the evaluation result, an approval is required |
-
-By default, an `automatic` approval strategy is used for evaluation result `pass` and `warning`.
-
-**Usage:**
-
-```
-- name: approval
-  properties: 
-    pass: automatic
-    warning: manual
-```
-
-**Note:** If the approval is the first task of a sequence, the approval service is not provided with the result from a previous task. In this case, it always falls back to the `manual` approval strategy.
-
-<details><summary>**Example:** Extended shipyard with a mandatory approval task in production</summary>
-
-<p>
-
-```yaml
-apiVersion: spec.keptn.sh/0.2.3
-kind: "Shipyard"
-metadata:
-  name: "shipyard-sockshop"
-spec:
-  stages:
-    - name: "production"
-      sequences:
-        - name: "delivery"
-          tasks:
+    apiVersion: spec.keptn.sh/0.2.3
+    kind: "Shipyard"
+    metadata:
+      name: "shipyard-sockshop"
+    spec:
+      stages:
+        - name: "dev"
+          sequences:
+          - name: "delivery"
+            tasks: 
             - name: "deployment"
-            - name: "approval"
-              properties:
-                pass: "manual"
-                warning: "manual"
             - name: "release"
-```
 
-</p>
-</details>
+        - name: "hardening"
+          sequences:
+          - name: "delivery"
+            triggeredOn:
+              - event: "dev.delivery.finished"
+            tasks: 
+            - name: "deployment"
+            - name: "release"
 
-#### Deployment
-
-Defines the deployment strategy (see [Continuous Delivery](../../continuous_delivery/)) used to deploy a new version of a service. Keptn supports deployment strategies of type:
-
-* `direct`: Deploys a new version of a service by replacing the old version of the service.
-* `blue_green_service`: Deploys a new version of a service next to the old one. After a successful validation of this new version, it replaces the old one and is marked as stable (i.e., it becomes the `primary`-version).
-* `user_managed` (experimental): Deploys a new version of a service by fetching the current helm-chart from the git repo, and just updating certain values.
-
-**Usage:**
-
-```
-- name: deployment
-  properties: 
-    deploymentstrategy: blue_green_service
-```
-
-```
-- name: deployment
-  properties: 
-    deploymentstrategy: direct
-```
-
-```
-- name: deployment
-  properties: 
-    deploymentstrategy: user_managed
-```
-
-#### Evaluation
-
-Defines the quality evaluation that is executed to verify the quality of a deployment based on its SLOs/SLIs.
-
-**Usage:**
-```
-- name: evaluation
-```
-
-#### Get-Action
-
-The get-action task is used to extract the desired remediation action from a remediation.yaml within a [remediation workflow](../../automated_operations/remediation).
-
-**Usage:**
-
-```
-- name: get-action
-```
-
-#### Release
-
-Defines the releasing task that is executed after a successful deployment happens. This means that production traffic is shifted towards the new deployment in this task.
-
-**Usage:**
-```
-- name: release
-```
-
-#### Action
-
-Defines the execution of a remediation action retrieved by `get-action`.
-
-**Usage:**
-```
-- name: action
-```
-
-#### Rollback
-
-Defines the rollback task that is executed when a rollback is triggered.
-
-**Usage:**
-```
-- name: rollback
-```
-
-#### Test
-
-Defines the test strategy used to validate a deployment. Keptn supports tests of type:
-
-* `functional`: Test a deployment based on functional tests.
-* `performance`: Test a deployment based on performance/load tests.
-
-**Usage:**
-```
-- name: test
-  properties: 
-    teststrategy: functional
-```
+        - name: "production"
+          sequences:
+          - name: "delivery"
+            triggeredOn:
+              - event: "hardening.delivery.finished"
+            tasks: 
+            - name: "deployment"
+            - name: "release"
 
 <details><summary>**Example:** Extended shipyard with functional tests in dev and performance tests in hardening
 </summary>
 
 <p>
 
-```yaml
-apiVersion: spec.keptn.sh/0.2.3
-kind: "Shipyard"
-metadata:
-  name: "shipyard-sockshop"
-spec:
-  stages:
-    - name: "dev"
-      sequences:
-        - name: "delivery"
-          tasks:
-            - name: "deployment"
-              properties:
-                deploymentstrategy: "direct"
-            - name: "test"
-              properties:
-                teststrategy: "functional"
-            - name: "evaluation"
-            - name: "release"
+    apiVersion: spec.keptn.sh/0.2.3
+    kind: "Shipyard"
+    metadata:
+      name: "shipyard-sockshop"
+    spec:
+      stages:
+        - name: "dev"
+          sequences:
+            - name: "delivery"
+              tasks:
+                - name: "deployment"
+                  properties:
+                    deploymentstrategy: "direct"
+                - name: "test"
+                  properties:
+                    teststrategy: "functional"
+                - name: "evaluation"
+                - name: "release"
 
-    - name: "staging"
-      sequences:
-        - name: "delivery"
-          triggeredOn:
-            - event: "dev.delivery.finished"
-          tasks:
-            - name: "deployment"
-              properties:
-                deploymentstrategy: "blue_green_service"
-            - name: "test"
-              properties:
-                teststrategy: "performance"
-            - name: "evaluation"
-            - name: "release"
-
-``` 
+        - name: "staging"
+          sequences:
+            - name: "delivery"
+              triggeredOn:
+                - event: "dev.delivery.finished"
+              tasks:
+                - name: "deployment"
+                  properties:
+                    deploymentstrategy: "blue_green_service"
+                - name: "test"
+                  properties:
+                    teststrategy: "performance"
+                - name: "evaluation"
+                - name: "release"
 
 </p>
 </details>
@@ -347,7 +160,7 @@ spec:
             - name: "release"
 ```
 
-**Result:** The next time Keptn triggers this sequence, the task is executed, meaning that a `sh.keptn.event.[task].triggered` event is sent out. Be sure to have a Keptn-service that listens to this event type and can execute it. 
+**Result:** The next time this sequence gets triggered by Keptn, the task will be executed meaning that a `sh.keptn.event.[task].triggered` event is sent out. Make sure to have a Keptn-service that listens to this event type and can execute it. 
 
 ### Add/Remove a task sequence to/from a stage
 
@@ -376,7 +189,7 @@ spec:
             - name: "release"
 ```
 
-**Use-case 1:** I would like to add an additional delivery process to the production stage that allows rolling out a hotfix without testing and evaluation. 
+**Use-case 1:** I would like to add an additional delivery process to the production stage that allows rolling-out a hotfix without testing and evaluation. 
 
 *Updated shipyard:*
 
@@ -456,211 +269,3 @@ spec:
 
 **Result:** After extending the shipyard as shown above, remediations should be executed when a problem event is retrieved (see [remediation workflow](../../automated_operations/remediation)).
 
-### Define a trigger for a sequence 
-
-An advanced and powerful feature of the shipyard is that you can define *triggers* to kick-off a sequence. Therefore, a sequence offers the `triggeredOn` property where a list of events can be specified. The event types you can list there are events that refer to the status of a sequence execution. Their name follows the pattern:
-
-* `[stage_name].[sequence_name].finished` 
-
-**Note:** It is not required to specify the full qualified event name which would be `sh.keptn.event.[stage_name].[sequence_name].finished` in this case
-
-In addition, a *match selector* can be added to an event to work as a filter on the `result` property of the event. Consequently, you can filter based on sequence executions that *failed* or *passed*, shown by the next example that filters on `failed`:
-
-```
-sequences:
-  - name: "rollback"
-    triggeredOn:
-      - event: "production.delivery.finished"
-        selector:
-          match:
-            result: failed
-```
-
-*Initial shipyard:*
-
-```
-apiVersion: "spec.keptn.sh/0.2.3"
-kind: "Shipyard"
-metadata:
-  name: "shipyard-sockshop"
-spec:
-  stages:
-    - name: "production"
-      sequences:
-        - name: "delivery"
-          tasks:
-            - name: "deployment"
-              properties:
-                deploymentstrategy: "blue_green_service"
-            - name: "test"
-              properties:
-                teststrategy: "functional"
-            - name: "evaluation"
-            - name: "release"
-```
-
-**Use-case:** I would like to add a process (additional sequence) that covers a failed delivery in the production stage by a notification and rollback task. 
-
-*Updated shipyard:*
-
-```
-apiVersion: "spec.keptn.sh/0.2.3"
-kind: "Shipyard"
-metadata:
-  name: "shipyard-sockshop"
-spec:
-  stages:
-    - name: "production"
-      sequences:
-        - name: "delivery"
-          tasks:
-            - name: "deployment"
-              properties:
-                deploymentstrategy: "blue_green_service"
-            - name: "test"
-              properties:
-                teststrategy: "functional"
-            - name: "evaluation"
-            - name: "release"
-
-        - name: "rollback"
-          triggeredOn:
-            - event: "production.delivery.finished"
-                selector:
-                  match:
-                    result: failed
-          tasks:
-            - name: "notification"
-            - name: "rollback"
-```
-
-**Result:** When, for example, the *delivery* sequence failed due to a failed test task, the event `sh.keptn.event.production.delivery.finished` with `result=failed` is sent out. Consequently, the *rollback* sequence is triggered based on the configuration of the `triggeredOn` and selector.
-
-## Trigger a sequence
-
-A shipyard file can contain multiple sequences in multiple stages.
-A specific `sequence` can be run by using the `POST /event` [Keptn API](../../reference/api/) with the following template:
-
-```json
-{
-    "data": {
-      "project": "[project]",
-      "service": "[service]",
-      "stage": "[stage]"
-    },
-    "source": "[my-source]",
-    "specversion": "1.0",
-    "type": "sh.keptn.event.[stage].[sequence-name].triggered",
-    "shkeptnspecversion": "0.2.3"
-}
-```
-
-The values between square brackets (`[]`) should be replaced based on your configuration:
-
-* `project`: your project name;
-* `service`: your service name;
-* `stage`: the stage in which your sequence is defined;
-* `sequence-name`: the sequence to trigger;
-* `my-source`: your source. More info are available in the [CloudEvents spec](https://github.com/cloudevents/spec/blob/v1.0/spec.md#source).
-
-### Examples
-
-In the following example, we define the `podtato-example` project that has the `helloservice` service. The shipyard file for the project defines three sequences:
-
-* `delivery` in the *hardening* stage;
-* `evaluation-only` in the *hardening* stage;
-* `delivery` in the *production* stage.
-
-```yaml
-apiVersion: "spec.keptn.sh/0.2.3"
-kind: "Shipyard"
-metadata:
-  name: "podtato-example"
-spec:
-  stages:
-    - name: "hardening"
-      sequences:
-        - name: "delivery"
-          tasks:
-            - name: "deployment"
-              properties:
-                deploymentstrategy: "blue_green_service"
-            - name: "test"
-              properties:
-                teststrategy: "performance"
-            - name: "evaluation"
-            - name: "release"
-        - name: "evaluation-only"
-          tasks:
-            - name: "evaluation"
-              properties:
-                teststrategy: "performance"
-    - name: "production"
-      sequences:
-        - name: "delivery"
-          triggeredOn:
-            - event: "hardening.delivery.finished"
-          tasks:
-            - name: "deployment"
-              properties:
-                deploymentstrategy: "blue_green_service"
-            - name: "release"
-```
-
-To trigger the `delivery` sequence in the *hardening* stage, post the following payload to the `POST /event` endpoint.
-
-```json
-{
-  "data": {
-    "project": "podtato-example",
-    "service": "helloservice",
-    "stage": "hardening"
-  },
-  "source": "https://github.com/keptn/keptn/cli#configuration-change",
-  "specversion": "1.0",
-  "time": "2022-02-01T12:50:04.720Z",
-  "type": "sh.keptn.event.hardening.delivery.triggered",
-  "shkeptnspecversion": "0.2.3"
-}
-```
-
-To trigger the `delivery` sequence in the *production* stage, post the following payload to the `POST /event` endpoint.
-
-```json
-{
-  "data": {
-    "project": "podtato-example",
-    "service": "helloservice",
-    "stage": "production"
-  },
-  "source": "https://github.com/keptn/keptn/cli#configuration-change",
-  "specversion": "1.0",
-  "time": "2022-02-01T12:50:04.720Z",
-  "type": "sh.keptn.event.production.delivery.triggered",
-  "shkeptnspecversion": "0.2.3"
-}
-```
-
-To trigger the `evaluation-only` sequence in the *hardening* stage, post the following payload to the `POST /event` endpoint.
-Since we want to trigger an evaluation, we need to provide addition properties about the evaluation timeframe. More information is provided in the
-[Quality Gates](../../quality_gates/get_started/) section of our documentation.
-
-```json
-{
-  "data": {
-    "evaluation": {
-      "end": "2022-02-01T09:36:11.311Z",
-      "start": "2022-02-01T09:31:11.311Z",
-      "timeframe": ""
-    },
-    "project": "podtato-example",
-    "service": "helloservice",
-    "stage": "hardening"
-  },
-  "source": "https://github.com/keptn/keptn/cli#configuration-change",
-  "specversion": "1.0",
-  "time": "2022-02-01T12:11:50.120Z",
-  "type": "sh.keptn.event.hardening.evaluation-only.triggered",
-  "shkeptnspecversion": "0.2.3"
-}
-```

--- a/content/docs/0.16.x/manage/triggers/index.md
+++ b/content/docs/0.16.x/manage/triggers/index.md
@@ -2,17 +2,24 @@
 title: Triggers
 description: Using triggers to kick off a sequence
 weight: 50
-keywords: [0.15.x-manage]
+keywords: [0.16.x-manage]
 aliases:
 ---
 
-You can define *triggers* to kick off a sequence in response to specific events.
+A Keptn sequence can be triggered in any of the following ways:
 
-## Define a trigger for a sequence 
+* Using the Keptn API
+* Using the Keptn CLI
+* From the Bridge UI
+* Using the `triggeredOn`property in the `shipyard` file.
 
-To define a trigger,
-use the `triggeredOn` property and specify a list of events.
-Use event types that refer to the status of a sequence execution.
+## Using triggeredOn in a sequence
+
+Use the `triggeredOn` property in a project's [shipyard](../../reference/files/shipyard) file
+to kick off a sequence in response to specific events.
+Essentially, this links sequences together to form chains of sequences.
+Specify a list of events to `triggeredOn`,
+using event types that refer to the status of a sequence execution.
 Their name follows the pattern:
 
 * `[stage_name].[sequence_name].finished` 

--- a/content/docs/0.16.x/manage/triggers/index.md
+++ b/content/docs/0.16.x/manage/triggers/index.md
@@ -1,0 +1,231 @@
+---
+title: Triggers
+description: Using triggers to kick off a sequence
+weight: 50
+keywords: [0.15.x-manage]
+aliases:
+---
+
+You can define *triggers* to kick off a sequence in response to specific events.
+
+## Define a trigger for a sequence 
+
+To define a trigger,
+use the `triggeredOn` property and specify a list of events.
+Use event types that refer to the status of a sequence execution.
+Their name follows the pattern:
+
+* `[stage_name].[sequence_name].finished` 
+
+**Note:** It is not necessary to specify the full qualified event name
+which, in this case, would be `sh.keptn.event.[stage_name].[sequence_name].finished`.
+
+A *match selector* can be added to an event to work as a filter on the `result` property of the event.
+This enables you to filter based on sequence executions that *failed* or *passed*
+as shown in the next example that filters on `failed`: 
+
+```
+sequences:
+  - name: "rollback"
+    triggeredOn:
+      - event: "production.delivery.finished"
+        selector:
+          match:
+            result: failed
+```
+
+*Initial shipyard:*
+
+```
+apiVersion: "spec.keptn.sh/0.2.3"
+kind: "Shipyard"
+metadata:
+  name: "shipyard-sockshop"
+spec:
+  stages:
+    - name: "production"
+      sequences:
+        - name: "delivery"
+          tasks:
+            - name: "deployment"
+              properties:
+                deploymentstrategy: "blue_green_service"
+            - name: "test"
+              properties:
+                teststrategy: "functional"
+            - name: "evaluation"
+            - name: "release"
+```
+
+**Use-case:** Add a process (additional sequence)
+that covers a failed delivery in the production stage with a notification and rollback task. 
+
+*Updated shipyard:*
+
+```
+apiVersion: "spec.keptn.sh/0.2.3"
+kind: "Shipyard"
+metadata:
+  name: "shipyard-sockshop"
+spec:
+  stages:
+    - name: "production"
+      sequences:
+        - name: "delivery"
+          tasks:
+            - name: "deployment"
+              properties:
+                deploymentstrategy: "blue_green_service"
+            - name: "test"
+              properties:
+                teststrategy: "functional"
+            - name: "evaluation"
+            - name: "release"
+
+        - name: "rollback"
+          triggeredOn:
+            - event: "production.delivery.finished"
+                selector:
+                  match:
+                    result: failed
+          tasks:
+            - name: "notification"
+            - name: "rollback"
+```
+
+**Result:** If the *delivery* sequence fails because of a failed test task,
+the event `sh.keptn.event.production.delivery.finished` with `result=failed` is sent out.
+This triggers the *rollback* sequence, based on the configuration of the `triggeredOn` and selector.
+
+## Trigger a sequence
+
+A [shipyard.yaml](../../reference/files/shipyard) file can contain multiple sequences in multiple stages.
+Use `POST /event` [Keptn API](../../reference/api/) to run a specific `sequence` with the following template:
+
+```json
+{
+    "data": {
+      "project": "[project]",
+      "service": "[service]",
+      "stage": "[stage]"
+    },
+    "source": "[my-source]",
+    "specversion": "1.0",
+    "type": "sh.keptn.event.[stage].[sequence-name].triggered",
+    "shkeptnspecversion": "0.2.3"
+}
+```
+
+Replace the values between square brackets (`[]`) based on your configuration:
+
+* `project`: your project name;
+* `service`: your service name;
+* `stage`: the stage in which your sequence is defined;
+* `sequence-name`: the sequence to trigger;
+* `my-source`: your source. More info are available in the [CloudEvents spec](https://github.com/cloudevents/spec/blob/v1.0/spec.md#source).
+
+### Examples
+
+In the following example, we define the `podtato-example` project that has the `helloservice` service.
+The [shipyard.yaml](../../reference/files/shipyard) file for the project defines three sequences:
+
+* `delivery` in the *hardening* stage;
+* `evaluation-only` in the *hardening* stage;
+* `delivery` in the *production* stage.
+
+```yaml
+apiVersion: "spec.keptn.sh/0.2.3"
+kind: "Shipyard"
+metadata:
+  name: "podtato-example"
+spec:
+  stages:
+    - name: "hardening"
+      sequences:
+        - name: "delivery"
+          tasks:
+            - name: "deployment"
+              properties:
+                deploymentstrategy: "blue_green_service"
+            - name: "test"
+              properties:
+                teststrategy: "performance"
+            - name: "evaluation"
+            - name: "release"
+        - name: "evaluation-only"
+          tasks:
+            - name: "evaluation"
+              properties:
+                teststrategy: "performance"
+    - name: "production"
+      sequences:
+        - name: "delivery"
+          triggeredOn:
+            - event: "hardening.delivery.finished"
+          tasks:
+            - name: "deployment"
+              properties:
+                deploymentstrategy: "blue_green_service"
+            - name: "release"
+```
+
+Post the following payload to the `POST /event` endpoint
+to trigger the `delivery` sequence in the *hardening* stage: the following payload should be posted
+
+```json
+{
+  "data": {
+    "project": "podtato-example",
+    "service": "helloservice",
+    "stage": "hardening"
+  },
+  "source": "https://github.com/keptn/keptn/cli#configuration-change",
+  "specversion": "1.0",
+  "time": "2022-02-01T12:50:04.720Z",
+  "type": "sh.keptn.event.hardening.delivery.triggered",
+  "shkeptnspecversion": "0.2.3"
+}
+```
+
+Post the following payload to the `POST /event` endpoint
+to trigger the `delivery` sequence in the *production* stage:
+
+```json
+{
+  "data": {
+    "project": "podtato-example",
+    "service": "helloservice",
+    "stage": "production"
+  },
+  "source": "https://github.com/keptn/keptn/cli#configuration-change",
+  "specversion": "1.0",
+  "time": "2022-02-01T12:50:04.720Z",
+  "type": "sh.keptn.event.production.delivery.triggered",
+  "shkeptnspecversion": "0.2.3"
+}
+```
+
+Post the following payload to the `POST /event` endpoint
+to trigger the `evaluation-only` sequence in the *hardening* stage.
+Since we want to trigger an evaluation, we need to provide addition properties that define the evaluation timeframe.
+More information is provided in the [Quality Gates](../../quality_gates/get_started/) section of our documentation.
+
+```json
+{
+  "data": {
+    "evaluation": {
+      "end": "2022-02-01T09:36:11.311Z",
+      "start": "2022-02-01T09:31:11.311Z",
+      "timeframe": ""
+    },
+    "project": "podtato-example",
+    "service": "helloservice",
+    "stage": "hardening"
+  },
+  "source": "https://github.com/keptn/keptn/cli#configuration-change",
+  "specversion": "1.0",
+  "time": "2022-02-01T12:11:50.120Z",
+  "type": "sh.keptn.event.hardening.evaluation-only.triggered",
+  "shkeptnspecversion": "0.2.3"
+}
+```

--- a/content/docs/0.16.x/reference/files/shipyard/index.md
+++ b/content/docs/0.16.x/reference/files/shipyard/index.md
@@ -43,16 +43,16 @@ The requirements are:
         - name: "production"
           sequences:
           - name: "<delivery-sequence>"
-            [triggeredOn:
+            triggeredOn:                                   # optional
                - event: "<event>.finished"
              tasks:
              - name: "delivery"
           - name: "remediation-sequence>"
-            [triggeredOn:
+            triggeredOn:                                   # optional
                -event: "<event>"
-                selector:
+                selector:                                  # optional
                   match:
-                    evaluation.result: "<result>"]
+                    evaluation.result: "<result>"
              tasks:
                 - name: "get-action"
                 - name: "action"

--- a/content/docs/0.16.x/reference/files/shipyard/index.md
+++ b/content/docs/0.16.x/reference/files/shipyard/index.md
@@ -1,17 +1,18 @@
 ---
-title: shipyard.yaml
+title: shipyard
 description: Control orchestation for a Keptn project
 weight: 715
 ---
 
-The *shipyard.yaml* file defines the activities to be performed for a Keptn project
+The shipyard is configured in the  *shipyard.yaml* file,
+which defines the activities to be performed for a Keptn project
 and the order in which those activities are executed.
 
 Each project must have one, and only one, *shipyard.yaml* file
 which is passed to the [**keptn create project**](../../cli/commands/keptn_create_project/) command.
 
-* Each *shipyard.yaml* file contains  one or more `stages`, which can be given any name that is meaningful.
-Examples are "dev", "hardening", "production", "remediation".
+* Each *shipyard* contains  one or more `stages`, which can be given any name that is meaningful.
+Examples are "development", "hardening", "production", and "remediation".
 A `stage` is a grouping of activities to be executed until the project is deployed and,
 optionally, a "production" stage that defines remediation activities
 that can be executed in response to issues detected on the production site.
@@ -19,9 +20,8 @@ that can be executed in response to issues detected on the production site.
 * Each `stage` must have one or more `sequences`, which can be given any name that is meaningful.
 A `sequence` defines the `tasks` to be performed and, optionally, an event that triggers that sequence.
 
-The following **Synopsis** shows all the constructions that are supported for a *shipyard.yaml* file
+The following **Synopsis** shows all the constructions that are supported for a *shipyard*
 although most projects only use some of the constructions.
-The requirements are:
 
 ## Synopsis
 
@@ -43,14 +43,14 @@ The requirements are:
         - name: "production"
           sequences:
           - name: "<delivery-sequence>"
-            triggeredOn:                                   # optional
+            triggeredOn:
                - event: "<event>.finished"
              tasks:
              - name: "delivery"
           - name: "remediation-sequence>"
-            triggeredOn:                                   # optional
+            triggeredOn:
                -event: "<event>"
-                selector:                                  # optional
+                selector:
                   match:
                     evaluation.result: "<result>"
              tasks:
@@ -96,7 +96,7 @@ about the ongoing initiative to overcome this limitation.
 A sequence is an ordered list of `task`s that are triggered sequentially
 and are part of a `stage`.
 By default, a sequence is a standalone section that runs and finishes,
-unless you specify the `triggeredOn` property for form a chain of sequences.
+unless you specify the `triggeredOn` property to form a chain of sequences.
 
 A sequence has the properties:
 
@@ -104,9 +104,9 @@ A sequence has the properties:
 * `tasks`: An array of tasks executed by the sequence in the declared order.
 * `triggeredOn` *(optional)*: An array of events that trigger the sequence.
     This property can be used to trigger a sequence once another sequence has been finished,
-    essentially forming chains of sequences..
+    essentially forming chains of sequences.
     In addition to specifying the sequence whose completion should activate the trigger,
-    You can define a `selector` that defines whether the sequence should be triggered
+    you can define a `selector` that defines whether the sequence should be triggered
     if the preceeding sequence has been executed successfuly, or had a `failed` or `warning` result.
     For example, the following sequence with the name `rollback` is only triggered
     if the sequence `delivery` in production had a result of `failed`:
@@ -120,7 +120,8 @@ A sequence has the properties:
 
     It is also possible to refer to certain tasks within the preceeding sequence.
     For example, if `match` is changed to `release.result: failed`,
-    the `rollback` sequence is executed only if the task `release` of the sequence `delivery` has a result of `failed`:
+    the `rollback` sequence is executed only if the task `release` of the sequence `delivery`
+    has a result of `failed`:
 
         - name: rollback
           triggeredOn:
@@ -129,7 +130,8 @@ A sequence has the properties:
               match:
                 release.result: failed
 
-    If no `selector` is specified, the sequence is triggered only if the preceeding `delivery` sequence has a result of `pass`:
+    If no `selector` is specified, the sequence is triggered
+    only if the preceeding `delivery` sequence has a result of `pass`:
 
         - name: rollback
           triggeredOn:
@@ -137,17 +139,19 @@ A sequence has the properties:
 
 **Task**
 
-A single `task` is the smallest executable unit and is contained in a `sequences` block. A task has the properties:
+A single `task` is the smallest executable unit and is contained in a `sequences` block.
+A task has the properties:
 
-* `name`: A unique name of the task
-* `triggeredAfter` *(optional)*: Wait time before task is triggered.
+* `name`: A unique name for the task
+* `triggeredAfter` *(optional)*: Wait time before the task is triggered.
 * `properties` *(optional)*: Task properties as individual `key:value` pairs.
   These properties are properties that the actioning tool requires
   and are consumed by the tool that executes the task.
   Typically, properties are passed in at runtime using JSON data
-  rather than having the data hardcoding into the *shipyard* file.
+  rather than having the data hardcoded into the *shipyard* file.
 
-Keptn supports a set of opinionated tasks for declaring a delivery or remediation sequence:
+Keptn supports a set of opinionated tasks for declaring a delivery or remediation sequence.
+Additional tasks may be defined for the services you integrate.
 
 * action
 * approval
@@ -160,7 +164,7 @@ In addition, the following two tasks are reserved
 although they are associated with specific services:
 
 * release (helm-service only)
-* test (jmeter-service)
+* test (jmeter-service only)
 
 Each of these are discussed below.
 
@@ -168,10 +172,6 @@ Each of these are discussed below.
 
     Indicates that a remediation action should be executed by an action provider.
     It is used within a [remediation workflow](../../../automated_operations/remediation).
-
-    *Synopsis:*
-
-        - name: action
 
 * `approval`
 
@@ -206,52 +206,53 @@ Each of these are discussed below.
 
     Defines the quality evaluation that is executed to verify the quality of a deplyoment based on its SLOs/SLIs.
 
-    *Synopsis:*
+    Use the optional `triggeredAfter` parameter to specify when to trigger the evaluation.
 
-        - name: evaluation
+    Set the `timeframe` property to specify the timespan to be evaluated.
+    For example, `timeframe: 5m` says that the quality gate evaluation looks at the previous five minutes.
+
+    `timeframe` must be specified but
+    you can specify the `timeframe` as part of the JSON payload
+    and pass it in when you trigger the sequence using curl
+    rather than hard-coding it in the file.
+    This makes the timeframe value dynamic.  For example:
+
+        {
+         "type": "sh.keptn.event.SomeStage.MySequence.triggered",
+         # Other fields removed for brevity
+         "data": {
+           "evaluation": {
+             "timeframe": "5m"
+           }
+        }
 
 * `get-action`
-    Extracts the desired remediation action from a *remediation.yaml* file
+    Extracts the desired remediation action from a *remediation* configuration
     within a [remediation workflow](../../../automated_operations/remediation).
-
-    *Synopsis:*
-
-        - name: get-action
 
 * `release`
 
     Defines the releasing task that is executed after a successful deployment occurs.
     This task shifts production trafic towards the new deployment.
 
-    *Synopsis:*
-
-        - name: release
-
 * `rollback`
 
     Defines the rollback task that is executed when a rollback is triggered.
-
-    *Synopsis:*
-
-        - name: rollback
 
 * `remediation`
 
     Defines whether remediation actions are enabled or not.
 
-    *Synopsis:*
-
-        - name: remediation
-
 For historical reasons and backward compatibility, the following tasks are reserved in Keptn
-although they are actually associated with services that run on the execution pland
+although they are actually associated with services that run on the execution plane
 rather than on the control plane.
 
 * `deployment`
 
     Defines the deployment strategy used to deploy a new version of a service.
     This is part of  *helm-service*, which assumes that Istio is installed on the cluster
-    and supports setting the deployment `strategy` to:
+    unless the Job Executor Service is installed in the cluster.
+    The deployment `strategy` is set to one of the following:
 
     * `direct`: Deploys a new version of a service by replacing the old version of the service.
     See [Direct deployments](../../../continuous_delivery/deployment_helm/#direct-deployments)
@@ -262,24 +263,16 @@ rather than on the control plane.
     by fetching the current Helm chart from the Git repo and updating appropriate values.
     See [Direct deployments](../../../continuous_delivery/deployment_helm/#user-managed-deployments)
 
-    *Synopsis:*
-
-        - name: deployment
-          properties:
-            deploymentstrategy: blue_green_service
-
 * `test`
 
-    Defines the test strategy used to validate a deployment with the jmeter-service..
-    The *jmeter-service* supports the `teststrategy` set to:
+    Defines the test strategy used to validate a deployment with the *jmeter-service*.
+    The *jmeter-service* supports setting the `teststrategy` to one of the following:
 
     * `functional`: Test a deployment based on functional tests.
     * `performance`: Test a deployment based on performance/load tests.
 
     Failed tests result in an automatic `rollback` of the latest deployment
     when using a blue/green deployment strategy.
-
-    *Synopsis:*
 
         - name: test
           properties:
@@ -314,7 +307,8 @@ that contain annotated examples for accomplishing various tasks.
 
 ## Files
 
-* Your *shipyard* file is named to match the value of the `Metadata` name field in the file.
+* Your *shipyard* is stored in the upstage Git repo for the project
+and  named to match the value of the `Metadata` name field in the shipyard file.
 
 ## Differences between versions
 

--- a/content/docs/0.16.x/reference/files/shipyard/index.md
+++ b/content/docs/0.16.x/reference/files/shipyard/index.md
@@ -281,6 +281,12 @@ about the initiative to allow adding/removing stages to/from a *shipyard* file.
 * See [Updating a shipyard](../../../manage/shipyard/#updating-a-shipyard)
 for information about modifications that can be made to a *shipyard* file.
 
+As a workaround, you can temporarily skip the execution of a particular stage by doing either of the following:
+
+* Temporarily remove the `triggeredOn` attribute for the stage you want to skip
+* Add an `approval` step as the first task of the stage you want to skip
+and then `Deny` the approvals 
+
 ## Example
 
 The **See also** section of this page references other pages in this documentation set


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

This PR does the following:
* Creates a reference page for the shipyard.yaml file to summarize the synopsis of the file.  We will certainly refine this page more and add xrefs to this file from other pages as we move forward but, if reviewers agree, this is the general shape of the page.
* Deletes old material from the manage/shipyard file that is now in this file.
* Creates a separate manage/triggers file.  Note that this is unchanged from what was previously in the manage/shipyard file so does not require review for this exercise.

Issues for review:
* Should this page be called "shipyard.yaml" or just "shipyard"?
* Are the elements in this file "fields" or "parameters" or something else?
* What should be included in the "Synopsis" section?  I tried to incorporate some tasks into the Synopsis but not sure if this works and exactly how to arrange them.
* How should we handle "optional" bits in the Synopsis?  I started to surround them with square brackets (e.g. [triggeredOn...] following man page conventions but I fear that may just muddle the issue, especially for a yaml file where indentation is so significant.  Opinions?  **Update**: @agardnerIT suggested we use comments to show what is optional so I tried that for a couple lines.  I'm not sure I like the results.  Perhaps we should not worry about showing what is optional in the Synopsis?  Almost everything in shipyard is optional, depending on what one is doing with the project.  Perhaps we should just explain what is optional in the prose description of each line.
* Should we include the mini-synopses in each task section or should we get all of that in the main "Synopsis" section?  If we keep them in the individual task section, is having the "Synopsis:" lead-in helpful or just noise?
* What should be on this page that is not currently included?  I am favoring keeping this terse with xrefs to other pages in the doc set for more details and examples but perhaps there is other information that should be included here.

This PR adds content to the unreleased 0.16.x tree and replaces https://github.com/keptn/keptn.github.io/pull/1234/ 