### PR TITLE
Fix xrefs for 0.15.x

### DIFF
--- a/content/docs/concepts/architecture/index.md
+++ b/content/docs/concepts/architecture/index.md
@@ -16,13 +16,13 @@ During the installation of Keptn, [NATS](https://nats.io/) is installed into the
 ## Keptn CLI
 The Keptn CLI needs to be installed on the local machine and is used to send commands to Keptn by interacting with the API of Keptn. To communicate with Keptn you need to know a shared secret that is generated during the installation and verified by the *api* component.
 
-**Note:** A dedicated Keptn CLI section is provided [here](../../0.14.x/reference/cli/), which helps you to get started and lists all available commands.
+**Note:** A dedicated Keptn CLI section is provided [here](../../0.15.x/reference/cli/), which helps you to get started and lists all available commands.
 
 ## Keptn Bridge
 
 The *Keptn Bridge* provides a user interface that shows all Keptn-managed projects and services. Besides, it gives an overview of the staging environment. 
 
-**Note:** A dedicated section for the Keptn Bridge is provided [here](../../0.14.x/reference/bridge/), which explains how to access it and shows the user interface.
+**Note:** A dedicated section for the Keptn Bridge is provided [here](../../0.15.x/bridge/), which explains how to access it and shows the user interface.
 
 ## Keptn Control Plane
 
@@ -36,7 +36,7 @@ The *api-gateway-nginx* component is the single point used for exposing Keptn to
 
 The *api* component provides a REST API that allows communicating with Keptn. It provides endpoints to authenticate, get metadata about the Keptn installation within the cluster, forwarding CloudEvents to the NATS cluster, and triggering evaluations for a service.
 
-**Note:** A dedicated Keptn API section is provided [here](../../0.14.x/reference/api/), which helps you to access the API and to explore the available endpoints.
+**Note:** A dedicated Keptn API section is provided [here](../../0.15.x/reference/api/), which helps you to access the API and to explore the available endpoints.
 
 ### mongodb-service
 
@@ -78,4 +78,4 @@ without having to authenticate. In this case, the distributor sidecars directly 
 - When an execution plane is operated outside of the Cluster, it has the possibility to communicate with the HTTP API exposed by the `api-gateway-nginx`. In this case, every request to the API has to be authenticated using the `keptn-api` token. 
 Also, the distributor sidecars do not have the possibility to directly connect to the NATS cluster, but they can be configured to fetch open `.triggered` events from the HTTP API.
 
-To read more about developing execution plane services, please refer to the following section in the docs: [Write a Keptn-service](../../0.14.x/integrations/custom_integration/), which helps you to implement a custom service for Keptn. 
+To read more about developing execution plane services, please refer to the following section in the docs: [Write a Keptn-service](../../0.15.x/integrations/custom_integration/), which helps you to implement a custom service for Keptn. 

--- a/content/docs/concepts/automated_operations/index.md
+++ b/content/docs/concepts/automated_operations/index.md
@@ -13,7 +13,7 @@ Keptn addresses this challenge by introducing the concept of micro-operations th
 
 Keptn complies with a declarative approach for configuring remediation and operations workflows as code on the level of individual microservices (rather than on applications). Consequently, this declaration is versioned next to the operational config and deployed with each new version of the microservice.
 
-Below is an example of a declarative `remediation.yaml` file as used in Keptn. The file defines two problem types and the respective remediation actions. In case of a response time degradation, new instances are scaled up and in the case of a failure rate increase, a feature is disabled. To learn more about the remediation configuration, please continue [here](../../0.14.x/automated_operations/remediation). 
+Below is an example of a declarative `remediation.yaml` file as used in Keptn. The file defines two problem types and the respective remediation actions. In case of a response time degradation, new instances are scaled up and in the case of a failure rate increase, a feature is disabled. To learn more about the remediation configuration, please continue [here](../../0.15.x/automated_operations/remediation). 
 
 ```yaml
 version: 0.2.0
@@ -50,7 +50,7 @@ spec:
 
 In Keptn, a remediation action or operational task is implemented as micro-operation. Such a micro-operation is reduced to the max, meaning that it is designed to execute a single action. This action is implemented for a single microservice rather than an entire application. Consequently, declarative instructions procedures are written on a per-microservice basis, which you can select and combine as needed.
 
-A micro-operation is implemented by an [action-provider](../../0.14.x/integrations/custom_integration/), which is a Keptn-service with a dedicated purpose. This type of service is responsible for executing an action (aka. micro-operation) and therefore might even use another tool. An action-provider starts working, when receiving a Keptn CloudEvent of type: `sh.keptn.event.action.triggered`. To learn more about the implementation of a micro-operation by an action-provider, please continue [here](../../0.14.x/automated_operations/action-provider). 
+A micro-operation is implemented by an [action-provider](../../0.15.x/integrations/custom_integration/), which is a Keptn-service with a dedicated purpose. This type of service is responsible for executing an action (aka. micro-operation) and therefore might even use another tool. An action-provider starts working, when receiving a Keptn CloudEvent of type: `sh.keptn.event.action.triggered`. To learn more about the implementation of a micro-operation by an action-provider, please continue [here](../../0.15.x/automated_operations/action-provider). 
 
 ## Event-driven Choreography
 

--- a/content/docs/concepts/delivery/index.md
+++ b/content/docs/concepts/delivery/index.md
@@ -11,7 +11,7 @@ Keptn allows to declaratively define *multi-stage delivery* workflows by definin
 
 ## Shipyard for Delivery Declaration
 
-The definition is manifested in a so-called *shipyard* file that defines a task sequence for delivery. It can hold multiple stages, each with a dedicated *deployment strategy*, *test strategy*, as well as a *remediation strategy*. Following this declarative approach, there is no need to write imperative pipeline code. Keptn takes the shipyard file and creates a multi-stage workflow each stage having a deployment strategy (e.g., blue/green), testing strategy (e.g., functional tests or performance tests), and an optional automated remediation strategy for triggering self-healing actions. To learn more about a shipyard configuration, please continue [here](../../0.14.x/continuous_delivery/multi_stage/).
+The definition is manifested in a so-called *shipyard* file that defines a task sequence for delivery. It can hold multiple stages, each with a dedicated *deployment strategy*, *test strategy*, as well as a *remediation strategy*. Following this declarative approach, there is no need to write imperative pipeline code. Keptn takes the shipyard file and creates a multi-stage workflow each stage having a deployment strategy (e.g., blue/green), testing strategy (e.g., functional tests or performance tests), and an optional automated remediation strategy for triggering self-healing actions. To learn more about a shipyard configuration, please continue [here](../../0.15.x/continuous_delivery/multi_stage/).
 
 Please take a look at an example of a multi-stage delivery with a *dev*, *hardening*, and *production* stage with blue/green deployment and automated problem remediation.  
 

--- a/content/docs/concepts/quality_gates/index.md
+++ b/content/docs/concepts/quality_gates/index.md
@@ -16,7 +16,7 @@ Keptn quality gates provide you a *declarative way* to define quality criteria o
 Keptn quality gates base on the concepts of *Service-Level Indicators (SLIs)* and *Service-Level Objectives (SLOs)*. Therefore, it is possible to declaratively describe the desired quality objective for your applications and services.
 
 1. The process of evaluating a quality gate can be triggered either via the Keptn CLI or the Keptn API. 
-1. Once triggered, Keptn fetches the SLIs from a data provider like [Prometheus or Dynatrace](../../0.14.x/quality_gates/sli-provider/). 
+1. Once triggered, Keptn fetches the SLIs from a data provider like [Prometheus or Dynatrace](../../0.15.x/quality_gates/sli-provider/). 
 1. Keptn evaluates the SLI against the SLOs that are defined for the application or service. 
 1. After evaluation and scoring, Keptn returns the result that can be either processed in an automated way by an existing CD pipeline or by the user to manually decide on the next steps (e.g., promotion to production or pushing it back to the developer for needed improvements).
 
@@ -29,13 +29,13 @@ Keptn quality gates base on the concepts of *Service-Level Indicators (SLIs)* an
 
 A service-level indicator is a *"carefully defined quantitative measure of some aspect of the level of service that is provided"* (as defined in the [Site-Reliability Engineering Book](https://landing.google.com/sre/sre-book/chapters/service-level-objectives/)). 
 
-An example of an SLI is the *response time* (also named request latency), which is the indicator of how long it takes for a request to respond with an answer. Other prominent SLIs are *error rate* (or failure rate), and throughput. Keptn defines all SLIs in a dedicated `sli.yaml` file to make SLIs reusable within several quality gates. To learn more about the SLI configuration, please continue [here](../../0.14.x/quality_gates/sli/). 
+An example of an SLI is the *response time* (also named request latency), which is the indicator of how long it takes for a request to respond with an answer. Other prominent SLIs are *error rate* (or failure rate), and throughput. Keptn defines all SLIs in a dedicated [sli.yaml](../../0.15.x/reference/files/sli/)  file to make SLIs reusable within several quality gates.
 
 ## What is a Service-Level Objective (SLO)?
 
 A service-level objective is *"a target value or range of values for a service level that is measured by an SLI."* (as defined in the [Site-Reliability Engineering Book](https://landing.google.com/sre/sre-book/chapters/service-level-objectives/)). 
 
-An example of an SLO can define that a specific request must return results within 100 milliseconds. Keptn quality gates can comprise several SLOs that are all evaluated and scored, based even on different weights for each SLO to consider different importance of each SLO. Keptn defines SLOs in a dedicated `slo.yaml`. To learn more about the SLO configuration, please continue [here](../../0.14.x/quality_gates/slo/). 
+An example of an SLO can define that a specific request must return results within 100 milliseconds. Keptn quality gates can comprise several SLOs that are all evaluated and scored, based even on different weights for each SLO to consider different importance of each SLO. Keptn defines SLOs in a dedicated [slo.yaml](../../0.15.x/reference/files/slo/) file.
 
 ## References
 


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

Fixes some xrefs from "Concepts" articles.  Mostly, xrefs that had 0.14.x hard-coded but a couple that should point to new reference pages and the Bridge section rather than Bridge pages that were under reference.