### PR TITLE
Configuration section rather than files

### DIFF
--- a/content/docs/0.16.x/reference/files/_index.md
+++ b/content/docs/0.16.x/reference/files/_index.md
@@ -1,4 +1,13 @@
 ---
-title: Files
-description: Reference pages for Keptn configuration files
+title: Configurations
+description: Reference pages for Keptn configurations
 ---
+
+Keptn configurations are most commonly defined in YAML files
+which are created on your local system then installed into your Keptn configuration with a specific command.
+This writes the configuration to you [upstream Git repo](../../manage/git_upstream),
+where Keptn accesses the configuration.
+
+The YAML syntax is generally easy to follow but be aware that the indentation is precise and important.
+For more information about YAML syntax,
+see the Fileformat [YAML](https://docs.fileformat.com/programming/yaml/) document.

--- a/content/docs/0.16.x/reference/files/sli/index.md
+++ b/content/docs/0.16.x/reference/files/sli/index.md
@@ -1,5 +1,5 @@
 ---
-title: sli.yaml
+title: sli
 description: Configure and add Service-Level Indicators (SLIs) to your service.
 weight: 725
 keywords: [0.16.x-quality_gates]

--- a/content/docs/0.16.x/reference/files/slo/index.md
+++ b/content/docs/0.16.x/reference/files/slo/index.md
@@ -1,5 +1,5 @@
 ---
-title: slo.yaml
+title: slo
 description: Configure and add Service-Level Objectives (SLO) to your service.
 weight: 740
 keywords: [0.16.x-quality_gates]


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

* Renamed Files section to Configuration section per discussion
* Renamed sli.yaml and slo.yaml to be sli and slo

That PR has one comment, questioning whether this section should be "Configuration Files" rather than just "Configurations".
I believe the consensus from the Developer Meeting was to just use "Configuration" but it is certainly open to discussion.

This replaces https://github.com/keptn/keptn.github.io/pull/1249 , which had contents that should have been in two PRs.
