### PR TITLE
Improve Auto Update to not use absolute URLS

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -64,12 +64,16 @@ jobs:
         env:
           SOURCE_VERSION_SLUG: ${{ env.SOURCE_VERSION_SLUG }}
           DOCS_PATH: "./content/docs/${{ env.SOURCE_VERSION_SLUG }}/reference/cli/commands"
+          RELATIVE_PATH: "../../../../"
         run: |
           if [[ ! -d "$DOCS_PATH" ]]; then
             mkdir -p "$DOCS_PATH"
           fi
           
           ./dist/keptn generate docs --dir="$DOCS_PATH"
+
+          # Replaces All Occurences of version links with a relative path
+          find $DOCS_PATH -print -type f -name '*.md' -exec sed -i "s@https://keptn.sh/docs/[[:digit:]][^/]*/@${RELATIVE_PATH}@g" {} \;
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -13,8 +13,6 @@ IgnoreDirs:
 # exlcuded because the paths do not exist for styles and contact
 - "404"
 IgnoreURLs:
-# not released therefore we ignore it
-- "0.16.0"
 # GitHub Urls are ignored due to Request Limitations and getting a 429 instead
 - "github.com/keptn/keptn/issues"
 - "github.com/keptn/keptn/commit"


### PR DESCRIPTION
Currently we are using absolute references within the CLI Docs,
this can be problematic and even our tooling might cause troubles
regarding that, with links to not released versions etc.

Signed-off-by: Simon Schrottner <simon.schrottner@dynatrace.com>