### PR TITLE
make 0.16.x show before 0.15.x

### DIFF
--- a/content/docs/0.16.x/_index.md
+++ b/content/docs/0.16.x/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Release 0.16.x
 linktitle: Release 0.16.x
-weight: 981
+weight: 980
 sidebar_multicard: true
 icon: docs
 hide: false


### PR DESCRIPTION
This updates the weight for the 0.16.x tree so it is displayed before the 0.15.x tree