### PR TITLE
Recommend "Explore Keptn" exercise in QuickStart

### DIFF
--- a/content/docs/quickstart/_index.md
+++ b/content/docs/quickstart/_index.md
@@ -9,7 +9,7 @@ hidechildren: true # this flag hides all sub-pages in the sidebar-multicard.html
 
 ***Note: We suggest that you use the newly-released [Explore Keptn](../explore) exercise,
 rather than the exercises in this page.
-That exercise  uses [KillerCoda](https://killercoda.com/areas)
+That exercise  uses the [KillerCoda](https://killercoda.com/areas) platform
 to provide more extensive information
 without requiring you to install any software locally.***
 


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

As discussed in the 22 June 2022 Community Meeting, we have published the Kilrcoda "Explore Keptn" exercise in the doc set but, for now, need to retain the old QuickStart.  This PR adds a note at the top of QuickStart recommending that people use the "Explore Keptn" exercise instead.