### PR TITLE
Make 0.17.x show before 0.16.x

### DIFF
--- a/content/docs/0.17.x/_index.md
+++ b/content/docs/0.17.x/_index.md
@@ -4,7 +4,7 @@ linktitle: Release 0.17.x
 weight: 979
 sidebar_multicard: true
 icon: docs
-hide: false
+hide: true
 aliases:
   - /docs/0.17.0/
 ---

--- a/content/docs/0.17.x/_index.md
+++ b/content/docs/0.17.x/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Release 0.17.x
 linktitle: Release 0.17.x
-weight: 980
+weight: 979
 sidebar_multicard: true
 icon: docs
-hide: true
+hide: false
 aliases:
   - /docs/0.17.0/
 ---

--- a/public/google90258e79df368ea0.html
+++ b/public/google90258e79df368ea0.html
@@ -1,1 +1,0 @@
-google-site-verification: google90258e79df368ea0.html


### PR DESCRIPTION
Modified weight for 0.17.x

This picked up the fact that I had to delete my public directory to clean up the html checking locally.  That directory should probably be in the .gitignore file, right?