### PR TITLE
Moving static file to correct folder

### DIFF
--- a/static/google90258e79df368ea0.html
+++ b/static/google90258e79df368ea0.html
@@ -1,0 +1,1 @@
+google-site-verification: google90258e79df368ea0.html


### PR DESCRIPTION
Within  #1275 we accidentally deleted our google site verification file (i am not sure if we still need it) - due to the fact, that it was just put into the `public` folder which contains the generated sources.
As this is a static file, it should have been placed wihtin `static` which will generate the same result, but `public` will be just an `output` directory, which can be fully ignored.

Signed-off-by: Simon Schrottner <simon.schrottner@dynatrace.com>