### PR TITLE
Installing Keptn CLI document enhanced

### DIFF
--- a/content/docs/quickstart/_index.md
+++ b/content/docs/quickstart/_index.md
@@ -77,13 +77,41 @@ You can also run additional `hello` sequences with: `keptn trigger sequence --se
 Now try the [Multi-Stage Delivery](#try-multi-stage-delivery) example and then [Auto-Remediation](#try-auto-remediation) (see below). 
 
 ## Keptn CLI
+Every release of Keptn provides binaries for the Keptn CLI. These binaries are available for Linux, macOS, and Windows.
 
-1) Download the Keptn Command Line Tool:
+There are multiple options how to get the Keptn CLI on your machine.
+
+* Easiest option, if you are running on a Linux or Mac OS:
+
 ```
 curl -sL https://get.keptn.sh | bash
 ```
+This will download and install the Keptn CLI automatically.
 
-2) Install Keptn core control plane and execution plane services for continuous delivery using the CLI:
+* Another option is to manually download the current release of the Keptn CLI
+
+1. Download the version for your operating system from [Download CLI](/keptn/keptn/releases/tag/0.7.3)
+
+2. Unpack the download
+3. Find the ```keptn```  binary in the unpacked directory
+4. Linux / macOS: Add executable permissions (```chmod +x keptn```), and move it to the desired destination (e.g. ```mv keptn /usr/local/bin/keptn```)
+
+- Windows: Copy the executable to the desired folder and add the executable to your PATH environment variable.
+
+Now, you should be able to run the Keptn CLI:
+
+- Linux / macOS
+
+```
+keptn --help
+```
+
+- Windows
+  
+ ```
+.\keptn.exe --help
+ ```
+ Install Keptn core control plane and execution plane services for continuous delivery using the CLI:
 ```
 keptn install -n keptn --use-case=continuous-delivery --endpoint-service-type=LoadBalancer
 ```


### PR DESCRIPTION
Fix: #1221

The following guide on how to install Keptn CLI (https://keptn.sh/docs/quickstart/) doesn't contain the better explanation as it is mentioned here:https://tutorials.keptn.sh/tutorials/keptn-full-tour-prometheus-07/index.html?index=..%2F..keptn07x#3

So after looking at it, the following changes have been made to improve the documentation on how to install Keptn CLI onto your OS.