### PR TITLE
docs: Update quickstart page for Keptn 0.17

### DIFF
--- a/content/docs/explore/index.md
+++ b/content/docs/explore/index.md
@@ -36,11 +36,11 @@ See [Keptn CLI](../0.16.x/reference/cli) for more information.
 
 2. Install the core Keptn control plane components and expose them via a LoadBalancer:
 ```
-helm repo add keptn https://charts.keptn.sh && helm repo update
-helm install keptn keptn/keptn \
+helm install keptn keptn --repo=https://charts.keptn.sh \
 -n keptn --create-namespace \
---wait \
---set=apiGatewayNginx.type=LoadBalancer
+--set=apiGatewayNginx.type=LoadBalancer \
+--set=continuousDelivery.enabled=true \
+--wait
 ```
 
 3. Install some standard Keptn execution plane components. These are additional microservices that handle specific tasks:

--- a/content/docs/explore/index.md
+++ b/content/docs/explore/index.md
@@ -40,7 +40,7 @@ helm repo add keptn https://charts.keptn.sh && helm repo update
 helm install keptn keptn/keptn \
 -n keptn --create-namespace \
 --wait \
---set=control-plane.apiGatewayNginx.type=LoadBalancer
+--set=apiGatewayNginx.type=LoadBalancer
 ```
 
 3. Install some standard Keptn execution plane components. These are additional microservices that handle specific tasks:

--- a/content/docs/quickstart/_index.md
+++ b/content/docs/quickstart/_index.md
@@ -19,18 +19,18 @@ or as [Docker](#keptn-hello-world-docker-based) containers in K3d
 and run some basic exercises that demonstrate Keptn functionality.
 
 You can install and run Keptn on virtually any Kubernetes cluster.
-See Install CLI and Keptn for detailed instructions
+See [Install Keptn CLI](../install/cli-install) and [Install Keptn using the Helm chart](../install/helm-install) for detailed instructions
 about creating a Keptn cluster locally or in the cloud.
 
 ## Helm
 
 1) Install core control plane components and expose via a LoadBalancer:
 ```
-helm repo add keptn https://charts.keptn.sh && helm repo update
-helm install keptn keptn/keptn \
+helm install keptn keptn --repo=https://charts.keptn.sh
 -n keptn --create-namespace \
---wait \
---set=control-plane.apiGatewayNginx.type=LoadBalancer
+--set=apiGatewayNginx.type=LoadBalancer \
+--set=continuousDelivery.enabled=true \
+--wait
 ```
 
 2) Install the execution plane components. These are additional microservices that will handle certain tasks:
@@ -78,14 +78,9 @@ Now try the [Multi-Stage Delivery](#try-multi-stage-delivery) example and then [
 
 ## Keptn CLI
 
-1) Download the Keptn Command Line Tool:
+1) Download the latest stable version of the Keptn Command Line Tool:
 ```
 curl -sL https://get.keptn.sh | bash
-```
-
-2) Install Keptn core control plane and execution plane services for continuous delivery using the CLI:
-```
-keptn install -n keptn --use-case=continuous-delivery --endpoint-service-type=LoadBalancer
 ```
 
 ## k3d Keptn

--- a/content/docs/quickstart/_index.md
+++ b/content/docs/quickstart/_index.md
@@ -26,7 +26,7 @@ about creating a Keptn cluster locally or in the cloud.
 
 1) Install core control plane components and expose via a LoadBalancer:
 ```
-helm install keptn keptn --repo=https://charts.keptn.sh
+helm install keptn keptn --repo=https://charts.keptn.sh \
 -n keptn --create-namespace \
 --set=apiGatewayNginx.type=LoadBalancer \
 --set=continuousDelivery.enabled=true \


### PR DESCRIPTION
### This PR
- updates the quickstart page with latest changes to the helm installation process according to Keptn 0.17