### PR TITLE
fix: correct webhook-service go templating

### DIFF
--- a/content/docs/0.12.x/integrations/webhooks/_index.md
+++ b/content/docs/0.12.x/integrations/webhooks/_index.md
@@ -97,7 +97,7 @@ Based on the Go templating capabilities, you can:
 
 * Define conditions: `"{{if .fieldName}}{{.fieldName}}{{ else }}No field name set{{ end }}"` 
 * Access an array element: `"{{ index .articles.Content 0 }}"`
-* Refer to attributes with non-string characters `"(index .data "incident-management-tool").url"`
+* Refer to attributes with non-alphanumeric characters `"{{ index .data "incident-management-tool".url }}"`
 
 *An example of a customized request payload using a condition on an array element:*
 

--- a/content/docs/0.13.x/integrations/webhooks/_index.md
+++ b/content/docs/0.13.x/integrations/webhooks/_index.md
@@ -97,7 +97,7 @@ Based on the Go templating capabilities, you can:
 
 * Define conditions: `"{{if .fieldName}}{{.fieldName}}{{ else }}No field name set{{ end }}"` 
 * Access an array element: `"{{ index .articles.Content 0 }}"`
-* Refer to attributes with non-string characters `"(index .data "incident-management-tool").url"`
+* Refer to attributes with non-alphanumeric characters `"{{ index .data "incident-management-tool".url }}"`
 
 *An example of a customized request payload using a condition on an array element:*
 

--- a/content/docs/0.14.x/integrations/webhooks/_index.md
+++ b/content/docs/0.14.x/integrations/webhooks/_index.md
@@ -97,7 +97,7 @@ Based on the Go templating capabilities, you can:
 
 * Define conditions: `"{{if .fieldName}}{{.fieldName}}{{ else }}No field name set{{ end }}"` 
 * Access an array element: `"{{ index .articles.Content 0 }}"`
-* Refer to attributes with non-string characters `"(index .data "incident-management-tool").url"`
+* Refer to attributes with non-alphanumeric characters `"{{ index .data "incident-management-tool".url }}"`
 
 *An example of a customized request payload using a condition on an array element:*
 

--- a/content/docs/0.15.x/integrations/webhooks/_index.md
+++ b/content/docs/0.15.x/integrations/webhooks/_index.md
@@ -97,7 +97,7 @@ Based on the Go templating capabilities, you can:
 
 * Define conditions: `"{{if .fieldName}}{{.fieldName}}{{ else }}No field name set{{ end }}"` 
 * Access an array element: `"{{ index .articles.Content 0 }}"`
-* Refer to attributes with non-string characters `"(index .data "incident-management-tool").url"`
+* Refer to attributes with non-alphanumeric characters `"{{ index .data "incident-management-tool".url }}"`
 
 *An example of a customized request payload using a condition on an array element:*
 

--- a/content/docs/0.16.x/integrations/webhooks/_index.md
+++ b/content/docs/0.16.x/integrations/webhooks/_index.md
@@ -97,7 +97,7 @@ Based on the Go templating capabilities, you can:
 
 * Define conditions: `"{{if .fieldName}}{{.fieldName}}{{ else }}No field name set{{ end }}"` 
 * Access an array element: `"{{ index .articles.Content 0 }}"`
-* Refer to attributes with non-string characters `"(index .data "incident-management-tool").url"`
+* Refer to attributes with non-alphanumeric characters `"{{ index .data "incident-management-tool".url }}"`
 
 *An example of a customized request payload using a condition on an array element:*
 

--- a/content/docs/0.17.x/integrations/webhooks/_index.md
+++ b/content/docs/0.17.x/integrations/webhooks/_index.md
@@ -97,7 +97,7 @@ Based on the Go templating capabilities, you can:
 
 * Define conditions: `"{{if .fieldName}}{{.fieldName}}{{ else }}No field name set{{ end }}"` 
 * Access an array element: `"{{ index .articles.Content 0 }}"`
-* Refer to attributes with non-string characters `"(index .data "incident-management-tool").url"`
+* Refer to attributes with non-alphanumeric characters `"{{ index .data "incident-management-tool".url }}"`
 
 *An example of a customized request payload using a condition on an array element:*
 


### PR DESCRIPTION
During reading the docs I found that there was a syntax error in using go-templating in webhooks.

This PR corrects the syntax error, and also slightly adapts the text (e.g., it's not about string characters, it's about alphanumeric characters. `@` is also a string, but it's not alphanumeric).