### PR TITLE
Fix sitemap base URL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,7 @@ title = "keptn | Cloud-native application life-cycle orchestration"
 theme = "hugo-serif-theme"
 relativeUrls = false
 enableEmoji = true
+baseUrl = "https://keptn.sh"
 
 ignoreFiles = [
 "^(.*/docs/0.7.x/*)$",

--- a/config.toml
+++ b/config.toml
@@ -1,10 +1,9 @@
-# baseURL = "https://keptn.sh/"
+baseURL = "https://keptn.sh/"
 languageCode = "en-us"
 title = "keptn | Cloud-native application life-cycle orchestration"
 theme = "hugo-serif-theme"
 relativeUrls = false
 enableEmoji = true
-baseUrl = "https://keptn.sh"
 
 ignoreFiles = [
 "^(.*/docs/0.7.x/*)$",


### PR DESCRIPTION
### This PR
- adds a baseURL to our hugo config
- This should solve the problem that the [sitemap for keptn.sh](https://keptn.sh/sitemap.xml) doesn't have full URLs inside, which is needed for SEO purposes