### PR TITLE
Keptn tools page: Add try keptn link and fix xref from 0.17.x to 0.18.x

### DIFF
--- a/content/docs/concepts/keptn-tools/index.md
+++ b/content/docs/concepts/keptn-tools/index.md
@@ -23,7 +23,7 @@ It allows for interoperability and any kinds of integrations in the Keptn ecosys
 
 ## Start with the shipyard
 
-Keptn's [shipyard](../../0.17.x/reference/files/shipyard) file is the blueprint for your Keptn environment.
+Keptn's [shipyard](../../0.18.x/reference/files/shipyard) file is the blueprint for your Keptn environment.
 While it may look like a pipeline, nowhere does it mention the tooling used to action each task.
 This is deliberate and by design.
 It is this factor that allows hot-swapping of tools.
@@ -134,3 +134,6 @@ to run your container or script
 
 More details are provided at the bottom of the Integrations page.
 
+## Try Keptn?
+
+Want to try out Keptn? Head to the [explore Keptn page](../../explore) to begin.


### PR DESCRIPTION
Closes #1349 

This PR:
- Adds a new section at the end of the "Keptn tools" page linking to the explore keptn docs

This will help guide potential users to try out Keptn.

Signed-off-by: agardnerit <adam@agardner.net>