### PR TITLE
Issue #1344 - Tidy up footer links

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,14 +14,13 @@
           <li><a href="/why-keptn/" class="footer-link">Why Keptn?</a></li>
           <li><a href="https://keptn.sh/docs" class="footer-link">Docs</a></li>
           <li><a href="https://tutorials.keptn.sh" class="footer-link">Tutorials</a></li>
-          <li><a href="https://github.com/keptn-contrib" class="footer-link">Integration</a></li>
+          <li><a href="https://github.com/keptn-contrib" class="footer-link">Integrations</a></li>
+          <li><a href="https://keptn.sh/docs/explore/" class="footer-link">Explore Keptn</a></li>
         </ul>
       </div>
       <div class="col-6 col-md-2">
         <p class="footer-title mb-2">Resources</p>
         <ul class="footer-links">
-          <li><a href="https://keptn.sh/docs/" class="footer-link">Docs</a></li>
-          <li><a href="https://tutorials.keptn.sh" class="footer-link">Tutorials</a></li>
           <li><a href="https://github.com/keptn/keptn" class="footer-link">Github</a></li>
           <li><a href="https://github.com/keptn/keptn/releases/" class="footer-link">Releases</a></li>
           <li><a href="https://github.com/keptn/keptn/issues" class="footer-link">Issues</a></li>


### PR DESCRIPTION
I removed the 'Docs' and 'Tutorials' form the resources,
added a 's' to 'Integration' and added an 'Explore Keptn' link, that leads to https://keptn.sh/docs/explore/

Signed-off-by: RoeiY <roeiyaacobi@gmail.com>