### PR TITLE
Updated footer.html

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -10,6 +10,7 @@ IgnoreDirs:
 - "docs/0.11."
 - "docs/0.12."
 - "docs/0.13."
+- "docs/0.14."
 # exlcuded because the paths do not exist for styles and contact
 - "404"
 IgnoreURLs:

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,7 +14,7 @@
           <li><a href="/why-keptn/" class="footer-link">Why Keptn?</a></li>
           <li><a href="https://keptn.sh/docs" class="footer-link">Docs</a></li>
           <li><a href="https://tutorials.keptn.sh" class="footer-link">Tutorials</a></li>
-          <li><a href="https://github.com/keptn-contrib" class="footer-link">Integrations</a></li>
+          <li><a href="https://keptn.sh/docs/integrations/" class="footer-link">Integrations</a></li>
           <li><a href="https://keptn.sh/docs/explore/" class="footer-link">Explore Keptn</a></li>
         </ul>
       </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,14 +14,13 @@
           <li><a href="/why-keptn/" class="footer-link">Why Keptn?</a></li>
           <li><a href="https://keptn.sh/docs" class="footer-link">Docs</a></li>
           <li><a href="https://tutorials.keptn.sh" class="footer-link">Tutorials</a></li>
-          <li><a href="https://github.com/keptn-contrib" class="footer-link">Integration</a></li>
+          <li><a href="https://github.com/keptn-contrib" class="footer-link">Integrations</a></li>
+          <li><a href="https://keptn.sh/docs/explore/" class="footer-link">Explore Keptn</a></li>
         </ul>
       </div>
       <div class="col-6 col-md-2">
         <p class="footer-title mb-2">Resources</p>
         <ul class="footer-links">
-          <li><a href="https://keptn.sh/docs/" class="footer-link">Docs</a></li>
-          <li><a href="https://tutorials.keptn.sh" class="footer-link">Tutorials</a></li>
           <li><a href="https://github.com/keptn/keptn" class="footer-link">Github</a></li>
           <li><a href="https://github.com/keptn/keptn/releases/" class="footer-link">Releases</a></li>
           <li><a href="https://github.com/keptn/keptn/issues" class="footer-link">Issues</a></li>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,7 +14,7 @@
           <li><a href="/why-keptn/" class="footer-link">Why Keptn?</a></li>
           <li><a href="https://keptn.sh/docs" class="footer-link">Docs</a></li>
           <li><a href="https://tutorials.keptn.sh" class="footer-link">Tutorials</a></li>
-          <li><a href="https://keptn.sh/docs/integrations/" class="footer-link">Integrations</a></li>
+          <li><a href="https://github.com/keptn-contrib" class="footer-link">Integrations</a></li>
           <li><a href="https://keptn.sh/docs/explore/" class="footer-link">Explore Keptn</a></li>
         </ul>
       </div>


### PR DESCRIPTION
fixes #1344
1. I removed the `Docs` & `Tutorials` Parts from Resources.
2. Added `s` to `integration`
3. Added `Explore Keptn` which takes us to the link: https://keptn.sh/docs/explore/

Signed-off-by: Omkar kulkarni [88308267+Omkar0114@users.noreply.github.com](mailto:88308267+Omkar0114@users.noreply.github.com)