### PR TITLE
explore Keptn fix links point to 0.16.x

### DIFF
--- a/content/docs/explore/index.md
+++ b/content/docs/explore/index.md
@@ -57,7 +57,7 @@ See [Install Keptn using the Helm chart](../0.18.x/install/../../install/helm-in
 for more details.
 
 Kubernetes provides methods other than LoadBalancer for exposing Keptn.
-See [Access options](../0.18.x/install/access) for more information.
+See [Access options](../0.18.x/../install/access/) for more information.
 
 See [Kubernetes support & Cluster size](../0.18.x/install/../../install/k8s-support)
 for information about supported versions of Kubernetes and sizing information.

--- a/content/docs/explore/index.md
+++ b/content/docs/explore/index.md
@@ -51,15 +51,15 @@ helm install helm-service keptn/helm-service -n keptn
 ```
 
   Note that you do not have to use these particular microservices.
-  See [Deploying Services](../0.18.x/manage/service) for more information.
+  See [Deploying Services](../0.18.x/define/service) for more information.
 
-See [Install Keptn using the Helm chart](../0.18.x/operate/advanced_install_options)
+See [Install Keptn using the Helm chart](../0.18.x/install/../../install/helm-install)
 for more details.
 
 Kubernetes provides methods other than LoadBalancer for exposing Keptn.
-See [Access options](../0.18.x/operate/install/#access-options) for more information.
+See [Access options](../0.18.x/install/access) for more information.
 
-See [Kubernetes support & Cluster size](../0.18.x/operate/k8s_support)
+See [Kubernetes support & Cluster size](../0.18.x/install/../../install/k8s-support)
 for information about supported versions of Kubernetes and sizing information.
 
 ### Create your first Keptn project

--- a/content/docs/explore/index.md
+++ b/content/docs/explore/index.md
@@ -8,12 +8,12 @@ hidechildren: true # this flag hides all sub-pages in the sidebar-multicard.html
 ---
 
 The [Keptn End-to-End Delivery](https://killercoda.com/keptn/scenario/keptn-end-to-end-delivery) exercise
-uses [KillerCoda](https://killercoda.com/) to quickly introduce you to Keptn
+uses [Killercoda](https://killercoda.com/) to quickly introduce you to Keptn
 without requiring you to install anything.
 In less than an hour, you will learn about the main features of Keptn and how to implement them.
 
-**Note:** The kilrcoda session expires after an hour or if it is idle for five minutes or longer
-so you should plan to sit down and do the exercise without interruptions..
+**Note:** The killercoda session expires after an hour or if it is idle for five minutes or longer
+so you should plan to sit down and do the exercise without interruptions.
 
 ## Next steps
 
@@ -32,7 +32,7 @@ You can install and run Keptn on virtually any Kubernetes cluster:
 curl -sL https://get.keptn.sh | bash
 ```
 
-See [Keptn CLI](../0.16.x/reference/cli) for more information.
+See [Keptn CLI](../0.18.x/reference/cli) for more information.
 
 2. Install the core Keptn control plane components and expose them via a LoadBalancer:
 ```
@@ -51,20 +51,20 @@ helm install helm-service keptn/helm-service -n keptn
 ```
 
   Note that you do not have to use these particular microservices.
-  See [Deploying Services](../0.16.x/manage/service) for more information.
+  See [Deploying Services](../0.18.x/manage/service) for more information.
 
-See [Install Keptn using the Helm chart](../0.16.x/operate/advanced_install_options)
+See [Install Keptn using the Helm chart](../0.18.x/operate/advanced_install_options)
 for more details.
 
 Kubernetes provides methods other than LoadBalancer for exposing Keptn.
-See [Access options](../0.16.x/operate/install/#access-options) for more information.
+See [Access options](../0.18.x/operate/install/#access-options) for more information.
 
-See [Kubernetes support & Cluster size](../0.16.x/operate/k8s_support)
+See [Kubernetes support & Cluster size](../0.18.x/operate/k8s_support)
 for information about supported versions of Kubernetes and sizing information.
 
 ### Create your first Keptn project
 
-Follow the information in [Manage Keptn Project/Service](../0.16.x/manage)
+Follow the information in [Manage Keptn Project/Service](../0.18.x/manage)
 to create your first Keptn project.
 
 ## How to get more help?


### PR DESCRIPTION
This PR:

- Fixes some naming issues (`kilrcoda` should be `Killercoda`)
- Fixes links point to an old release on the explore page (from `0.16.x` to `0.18.x`)

Signed-off-by: agardnerit <adam@agardner.net>