### PR TITLE
Add Gitea provisioner

### DIFF
--- a/content/docs/0.18.x/api/git_provisioning/index.md
+++ b/content/docs/0.18.x/api/git_provisioning/index.md
@@ -20,6 +20,13 @@ This feature is enabled via the Helm value [`control-plane.features.automaticPro
 
 ---
 
+### Available Provisioners
+
+- [Gitea](https://github.com/keptn-sandbox/keptn-gitea-provisioner-service)
+- Help us add more by [creating an issue](https://github.com/keptn/integrations/issues/new?assignees=&labels=integrations&template=integration_template.yaml&title=%5Bintegration%5D+) and / or filing a Pull Request.
+
+]---
+
 ### Resources
 
 [Swagger Documentation](../../../../api/)


### PR DESCRIPTION
This PR:

- Adds a section for available Git provisioners to the correct page
- Adds Gitea as an available provisioner
- Adds text and links for new integrations

Signed-off-by: agardnerit <adam@agardner.net>