### PR TITLE
Usability / SEO: Add image alt and title tags

### DIFF
--- a/layouts/partials/tools-cards.html
+++ b/layouts/partials/tools-cards.html
@@ -6,21 +6,21 @@
     <div class="teaser-card-content">
       <div class="teaser-card-container">
         <div class="teaser-card teaser-card--smallPadding mb-4">
-          <img src="/images/home/integrations/tools-delivery-argo.png">
+          <img alt="Argo" title="Argo" src="/images/home/integrations/tools-delivery-argo.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding mb-4">
-          <img src="/images/home/integrations/tools-delivery-azure.png">
+          <img alt="Azure DevOps" title="Azure DevOps" src="/images/home/integrations/tools-delivery-azure.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding mb-4">
-          <img src="/images/home/integrations/tools-delivery-gitlab.png">
+          <img alt="GitLab" title="GitLab" src="/images/home/integrations/tools-delivery-gitlab.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding">
-          <img src="/images/home/integrations/tools-delivery-helm.png">
+          <img alt="Helm" title="Helm" src="/images/home/integrations/tools-delivery-helm.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding">
-          <img src="/images/home/integrations/tools-delivery-jenkins.png">
+          <img alt="Jenkins" title="Jenkins" src="/images/home/integrations/tools-delivery-jenkins.png">
         </div>
-        <a class="teaser-card teaser-card--smallPadding teaser-card--outline" href="https://github.com/keptn-sandbox/contributing">
+        <a alt="Suggest or contribute an integration" title="Suggest or contribute an integration" class="teaser-card teaser-card--smallPadding teaser-card--outline" href="https://github.com/keptn/integrations/issues/new?assignees=&labels=integrations&template=integration_template.yaml&title=%5Bintegration%5D+">
         </a>
       </div>
     </div>
@@ -32,21 +32,21 @@
     <div class="teaser-card-content">
       <div class="teaser-card-container">
         <div class="teaser-card teaser-card--smallPadding mb-4">
-          <img src="/images/home/integrations/tools-observability-dynatrace.png">
+          <img alt="Dynatrace" title="Dynatrace" src="/images/home/integrations/tools-observability-dynatrace.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding mb-4">
-          <img src="/images/home/integrations/tools-observability-grafana.png">
+          <img alt="Grafana" title="Grafana" src="/images/home/integrations/tools-observability-grafana.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding mb-4">
-          <img src="/images/home/integrations/tools-observability-opentelementry.png">
+          <img alt="OpenTelemetry" title="OpenTelemetry" src="/images/home/integrations/tools-observability-opentelementry.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding">
-          <img src="/images/home/integrations/tools-observability-prometheus.png">
+          <img alt="Prometheus" title="Prometheus" src="/images/home/integrations/tools-observability-prometheus.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding">
-          <img src="" data-proofer-ignore>
+          <img alt="Your Tool" title="Your Tool" src="" data-proofer-ignore />
         </div>
-        <a class="teaser-card teaser-card--smallPadding teaser-card--outline" href="https://github.com/keptn-sandbox/contributing">
+        <a alt="Suggest or contribute an integration" title="Suggest or contribute an integration" class="teaser-card teaser-card--smallPadding teaser-card--outline" href="https://github.com/keptn/integrations/issues/new?assignees=&labels=integrations&template=integration_template.yaml&title=%5Bintegration%5D+">
         </a>
       </div>
     </div>
@@ -58,21 +58,21 @@
     <div class="teaser-card-content">
       <div class="teaser-card-container">
         <div class="teaser-card teaser-card--smallPadding mb-4">
-          <img src="/images/home/integrations/tools-testing-jmeter.png">
+          <img alt="JMeter" title="JMeter" src="/images/home/integrations/tools-testing-jmeter.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding mb-4">
-          <img src="/images/home/integrations/tools-testing-litmus.png">
+          <img alt="LitmusChaos" title="LitmusChaos" src="/images/home/integrations/tools-testing-litmus.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding mb-4">
-          <img src="/images/home/integrations/tools-testing-locust.png">
+          <img alt="Locust" title="Locust" src="/images/home/integrations/tools-testing-locust.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding ">
-          <img src="/images/home/integrations/tools-testing-neoload.png">
+          <img alt="NeoLoad" title="NeoLoad" src="/images/home/integrations/tools-testing-neoload.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding ">
-          <img src="/images/home/integrations/tools-testing-selenium.png">
+          <img alt="Selenium" title="Selenium" src="/images/home/integrations/tools-testing-selenium.png">
         </div>
-        <a class="teaser-card teaser-card--smallPadding teaser-card--outline" href="https://github.com/keptn-sandbox/contributing">
+        <a alt="Suggest or contribute an integration" title="Suggest or contribute an integration" class="teaser-card teaser-card--smallPadding teaser-card--outline" href="https://github.com/keptn/integrations/issues/new?assignees=&labels=integrations&template=integration_template.yaml&title=%5Bintegration%5D+">
         </a>
       </div>
     </div>
@@ -84,21 +84,21 @@
     <div class="teaser-card-content">
       <div class="teaser-card-container">
         <div class="teaser-card teaser-card--smallPadding mb-4">
-          <img src="/images/home/integrations/tools-notifications-keptn.png">
+          <img alt="Any tool via webhook" title="Any tool via webhook" src="/images/home/integrations/tools-notifications-webhook.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding mb-4">
-          <img src="/images/home/integrations/tools-notifications-slack.png">
+          <img alt="Slack" title="Slack" src="/images/home/integrations/tools-notifications-slack.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding mb-4">
-          <img src="/images/home/integrations/tools-notifications-teams.png">
+          <img alt="MS Teams" title="MS Teams" src="/images/home/integrations/tools-notifications-teams.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding ">
-          <img src="/images/home/integrations/tools-notifications-webex.png">
+          <img alt="Cisco Webex" title="Cisco Webex" src="/images/home/integrations/tools-notifications-webex.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding ">
-          <img src="/images/home/integrations/tools-notifications-webhook.png">
+          <img alt="Your Tool" title="Your Tool" src="" data-proofer-ignore />
         </div>
-        <a class="teaser-card teaser-card--smallPadding teaser-card--outline" href="https://github.com/keptn-sandbox/contributing">
+        <a alt="Suggest or contribute an integration" title="Suggest or contribute an integration" class="teaser-card teaser-card--smallPadding teaser-card--outline" href="https://github.com/keptn/integrations/issues/new?assignees=&labels=integrations&template=integration_template.yaml&title=%5Bintegration%5D+">
         </a>
       </div>
     </div>
@@ -110,21 +110,21 @@
     <div class="teaser-card-content">
       <div class="teaser-card-container">
         <div class="teaser-card teaser-card--smallPadding mb-4">
-          <img src="/images/home/integrations/tools-automation-ansible.png">
+          <img alt="Ansible" title="Ansible" src="/images/home/integrations/tools-automation-ansible.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding mb-4">
-          <img src="/images/home/integrations/tools-automation-bash.png">
+          <img alt="Bash" title="Bash" src="/images/home/integrations/tools-automation-bash.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding mb-4">
-          <img src="/images/home/integrations/tools-automation-python.png">
+          <img alt="Python" title="Python" src="/images/home/integrations/tools-automation-python.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding">
-          <img src="/images/home/integrations/tools-automation-servicenow.png">
+          <img alt="ServiceNow" title="ServiceNow" src="/images/home/integrations/tools-automation-servicenow.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding">
-          <img src="/images/home/integrations/tools-automation-webhook.png">
+          <img alt="Any container or external tool" title="Any container or external tool" src="/images/home/integrations/tools-automation-webhook.png">
         </div>
-        <a class="teaser-card teaser-card--smallPadding teaser-card--outline" href="https://github.com/keptn-sandbox/contributing">
+        <a alt="Suggest or contribute an integration" title="Suggest or contribute an integration" class="teaser-card teaser-card--smallPadding teaser-card--outline" href="https://github.com/keptn/integrations/issues/new?assignees=&labels=integrations&template=integration_template.yaml&title=%5Bintegration%5D+">
         </a>
       </div>
     </div>

--- a/layouts/partials/tools-cards.html
+++ b/layouts/partials/tools-cards.html
@@ -44,7 +44,6 @@
           <img alt="Prometheus" title="Prometheus" src="/images/home/integrations/tools-observability-prometheus.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding">
-          <img alt="Your Tool" title="Your Tool" src="" data-proofer-ignore />
         </div>
         <a alt="Suggest or contribute an integration" title="Suggest or contribute an integration" class="teaser-card teaser-card--smallPadding teaser-card--outline" href="https://github.com/keptn/integrations/issues/new?assignees=&labels=integrations&template=integration_template.yaml&title=%5Bintegration%5D+">
         </a>
@@ -96,7 +95,6 @@
           <img alt="Cisco Webex" title="Cisco Webex" src="/images/home/integrations/tools-notifications-webex.png">
         </div>
         <div class="teaser-card teaser-card--smallPadding ">
-          <img alt="Your Tool" title="Your Tool" src="" data-proofer-ignore />
         </div>
         <a alt="Suggest or contribute an integration" title="Suggest or contribute an integration" class="teaser-card teaser-card--smallPadding teaser-card--outline" href="https://github.com/keptn/integrations/issues/new?assignees=&labels=integrations&template=integration_template.yaml&title=%5Bintegration%5D+">
         </a>


### PR DESCRIPTION
This PR:

- Adds  `alt` and `title` attributes to homepage integrations
- Changes "add tool" links to point to `https://github.com/keptn/integrations` as the funnel for new tooling integrations

Helps with SEO, accessibility and usability. Now when a user hovers over a logo, they see the name of the integration. I no longer need to know what logo I'm looking at

Signed-off-by: agardnerit <adam@agardner.net>