### PR TITLE
Update contributing integrations wording

### DIFF
--- a/content/docs/integrations/_index.md
+++ b/content/docs/integrations/_index.md
@@ -11,6 +11,8 @@ hidechildren: true # this flag hides all sub pages in the sidebar-multicard.html
 Keptn as a control-plane integrates with various different tools and can be extended with your own tools.
 In the following you'll find integrations that are already provided by the Keptn team and its community.
 
+Scroll to the bottom of this page to request a new integration or submit your own.
+
 {{< rawhtml >}}
 <input id="services-search" type="text" placeholder="Search">
 <button class="btn filterBtn" value="show-all">Show all</button>
@@ -48,14 +50,20 @@ In the following you'll find integrations that are already provided by the Keptn
 <div class="artifacthub-widget-group" data-url="https://artifacthub.io/packages/search?kind=10&sort=relevance&page=1&ts_query_web=" data-theme="light" data-header="false" data-color="#417598" data-stars="false" data-responsive="true" data-loading="true"></div><script async src="https://artifacthub.io/artifacthub-widget.js"></script>
 {{< /rawhtml >}}
 
+### Request a New Integration
+
+Need support for a new tool which isn't listed above? Start by [creating an issue here](https://github.com/keptn/integrations/issues/new?assignees=&labels=integrations&template=integration_template.yaml&title=%5Bintegration%5D+).
+
 ### Contributing
 
-- If you identify a bug you would like to report, please create an issue in the repository of the Keptn-service or speak to us on [Keptn Slack](https://slack.keptn.sh).
+- Identified a bug? Please create an issue in the relevant repository (not the [main Keptn repo](https://github.com/keptn/keptn)) or speak to us on [Slack](https://slack.keptn.sh).
 
-- As long as your tool can either except a webhook trigger OR be containerised, Keptn will be able to orchestrate your tool.
+- Want to submit an integration you have developed? Start by [creating an issue here](https://github.com/keptn/integrations/issues/new?assignees=&labels=integrations&template=integration_template.yaml&title=%5Bintegration%5D+).
 
-- If your tool is deployed in a non-container way, there are options for integration. Please reach out to discuss on [Slack](https://slack.keptn.sh).
+- Developing an integration and need help? Join the `#keptn-integrations` channel on [Slack](https://slack.keptn.sh).
 
-- Want to submit or request a new integration? Start by [creating an issue here](https://github.com/keptn/integrations/issues/new?assignees=&labels=integrations&template=integration_template.yaml&title=%5Bintegration%5D+).
+- Can your tool be triggered via a webhook? Keptn can orchestrate it with zero development using the out-of-the-box webhook service.
+  
+- Can your tool be containerised? The [job executor service](https://github.com/keptn-contrib/job-executor-service) can run your container.
 
-- Developing an integration and need help? Join `#help-integrations` on [Keptn Slack](https://slack.keptn.sh).
+- If your tool is deployed outside a container, there are options for integration. Please reach out to discuss on [Slack](https://slack.keptn.sh).

--- a/content/docs/integrations/_index.md
+++ b/content/docs/integrations/_index.md
@@ -50,12 +50,12 @@ In the following you'll find integrations that are already provided by the Keptn
 
 ### Contributing
 
-- If you identify a bug you would like to report, please create an issue in the repository of the Keptn-service.
+- If you identify a bug you would like to report, please create an issue in the repository of the Keptn-service or speak to us on [Keptn Slack](https://slack.keptn.sh).
 
-- If you need more information on version compatibility, please go to the repository where a compatibility-matrix should be provided.
+- As long as your tool can either except a webhook trigger OR be containerised, Keptn will be able to orchestrate your tool.
 
-- A template for getting started with writing your Keptn service is provided here: https://github.com/keptn-sandbox/keptn-service-template-go
+- If your tool is deployed in a non-container way, there are options for integration. Please reach out to discuss on [Slack](https://slack.keptn.sh).
 
-- Please follow the [contributions guide](https://github.com/keptn-sandbox/contributing) for contributing it to Keptn Sandbox.
+- Want to submit or request a new integration? Start by [creating an issue here](https://github.com/keptn/integrations/issues/new?assignees=&labels=integrations&template=integration_template.yaml&title=%5Bintegration%5D+).
 
-- The integration overview is managed from the [keptn-sandbox/artifacthub repository](https://github.com/keptn-sandbox/artifacthub). If you have any new integration feel free to add an entry there.
+- Developing an integration and need help? Join `#help-integrations` on [Keptn Slack](https://slack.keptn.sh).


### PR DESCRIPTION
This PR:

- Slightly alters the wording on the `docs/integrations` page to funnel people to the keptn/integrations repo
- It also adds links to Slack for those stuck

Signed-off-by: agardnerit <adam@agardner.net>