### PR TITLE
[BAD] Add quick installation demo video and synchronize doc and video

### DIFF
--- a/content/docs/install/helm-install/index.md
+++ b/content/docs/install/helm-install/index.md
@@ -6,63 +6,123 @@ weight: 40
 
 Keptn is installed using a Helm chart using the Helm CLI.
 You must install the [Helm CLI](https://helm.sh)
-and the [Keptn CLI](../cli-install)
 before attempting to install Keptn.
 
+You probably want to also install the [Keptn CLI](../cli-install)
+before installing Keptn.
+It is possible to do most of what you need to do on modern releases of Keptn without the Keptn CLI
+but the CLI provides additional functionality that is useful.
 After installing Keptn,
 you must [authenticate the Keptn CLI](../authenticate-cli-bridge/#authenticate-keptn-cli). 
 
 Keptn consists of a **Control Plane** and an **Execution Plane**.
 
-* The **Control Plane** allows using Keptn for the [Quality Gates](../../concepts/quality_gates/)
-  and [Automated Operations](../../concepts/automated_operations/).
+* The **Control Plane** is the minimum set of components that are required
+  to run a Keptn instance  and to manage projects, stages, and services;
+  to handle events; and to provide integration points.
+  The control plane orchestrates the task sequences defined in Shipyard
+  but does not actively execute the tasks.
   The Keptn Control Plane can run with no Execution Plane configured.
-* The **Control Plane with the Execution Plane** is required to implement
-  [Continuous Delivery](../../concepts/delivery/)
-  on top of Quality Gates and Automated Operations..
-  * Note that you must install either the
-  [Job Executor Service](https://artifacthub.io/packages/keptn/keptn-integrations/job-executor-service)
-  or [Istio](https://istio.io) on the Kubernetes cluster(s) where the Execution Plane is installed.
+
+  The Control Plane can implement the [Quality Gates](../../concepts/quality_gates/)
+  and [Automated Operations](../../concepts/automated_operations/) features
+  but does not run microservices that integrate other tools with Keptn.
+
+* The **Execution Plane** runs the microservices that integrate other tools with Keptn
+  and is installed when you install the first microservice on the cluster.
+  For example, the JMeter test tool runs on the Execution Plane
+  and installing it installs the Execution Plane.
+  As another example, the [Continuous Delivery](../../concepts/delivery/) feature
+  requires that you install either the
+[Job Executor Service](https://artifacthub.io/packages/keptn/keptn-integrations/job-executor-service)
+or [Istio](https://istio.io) on the Kubernetes cluster(s)
+and they execute on the Execution Plane.
 
 See [Architecture](../../concepts/architecture) for more information
 about the Control Plane and the Execution Plane.
 
-Keptn can be installed on an existing Kubernetes cluster that hosts other software
+You have the following installation options:
+
+* Both the Keptn Control Plane and the Execution Plane
+can be installed on an existing Kubernetes cluster that hosts other software
 or on a dedicated Keptn Kubernetes cluster.
-The Control Plane and Execution Plane can also be installed on separate Kubernetes clusters;
+* The Control Plane and Execution Plane can also be installed on separate Kubernetes clusters;
 see [Multi-cluster setup](../multi-cluster) for instructions.
 * In a multi-cluster setup, one Keptn Control Plane can support multiple Execution Planes
 that are installed on different clusters.
 
-## Control Plane installation options
+## Install Control Plane
 
-You must specify the [access option](../access) when you install
-the Keptn Control Plane.
+To install the Control Plane, you must do the following:
 
-* Install Keptn control-plane with Continuous Delivery support and exposed on a [LoadBalancer](../access/#option-1-expose-keptn-via-a-loadbalancer):
+* Define the Keptn chart repository
+* Install Keptn into the `keptn` namespace on the Kubernetes cluster
+* Expose the [API gateway's NGINX](../../concepts/architecture/#api-gateway-nginx) service
+  that controls how Keptn communicates with the internet.
+  See [Choose access option](../access) for details about all the options
+  that are available and how to install and use them.
+  You can also do this after installation.
+* You may also want to modify the Keptn configuration options.
+  This is discussed more below.
+
+### Sample installation commands
+
+* **Simple Keptn installation**
+
+  The following commands provide a basic Keptn installation,
+  Because the install command does not expose the API gateway's NGINX service,
+  we use the **kubectl** command to implement port forwarding,
+  which implements the Kubernetes [LoadBalancer](../access/#option-1-expose-keptn-via-a-loadbalancer):**:
+   ```
+   helm repo add keptn https://charts.keptn.sh
+   helm install keptn keptn/keptn -nkeptn --createnamespace
+   kubectl -n keptn port-forward svc /api-gateway-nginx 8080:8080
+   ```
+   This command is useful for creating a basic Keptn installation
+   to use for study or demonstration.
+   It may not be adequate for a production Keptn installation.
+
+   *Watch a video demonstration of a simple installation [here](https://www.youtube.com/watch?v=neAqh4fAz-k).*
+
+  The following commands are appropriate for installing a fully-functional production Keptn instance.
+  They use the following options:
+
+    * `--version 0.18.1` -- Keptn release to be installed
+      If you do not specify the release, Helm uses the latest release.
+
+    * `--repo=https://charts.keptn.sh` -- the location of the Helm chart
+      (rather than using the `helm repo add` command shown above).
+    * `apiGatewayNginx.type=<access-option>` -- this is necessary to access
+      the Keptn Bridge UI.
+      `<*access-option*>` must be `LoadBalancer`, `NodePort`, `Ingress`, or `Port-forward`.
+      See [Choose access options](../access/) for details.
+    * `--set=continuousDelivery.enabled=true` -- install Continuous Delivery support
+      for this Keptn instance.
+
+* **Install Keptn control-plane with Continuous Delivery support and exposed on a LoadBalancer**
+    ```
+    helm install keptn keptn --version 0.18.1 -n keptn --repo=https://charts.keptn.sh --create-namespace --wait --set=continuousDelivery.enabled=true,apiGatewayNginx.type=LoadBalancer
+    ```
+
+* **Use a LoadBalancer for api-gateway-nginx**
 
 ```
-helm install keptn keptn --version 0.18.1 -n keptn --repo=https://charts.keptn.sh --create-namespace --wait --set=continuousDelivery.enabled=true,apiGatewayNginx.type=LoadBalancer
-```
-
-* Use a LoadBalancer for api-gateway-nginx
-
-```console
 helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.18.1 --repo=https://charts.keptn.sh --set=apiGatewayNginx.type=LoadBalancer
 ```
 
-* Install Keptn with an ingress object
+* **Install Keptn with an ingress object**
 
   If you are already using an [Ingress Controller](../access/#option-3-expose-keptn-via-an-ingress)
   and want to create an ingress object for Keptn,
-  you can leverage the ingress section of the Helm chart. By default `enabled` is set to false.
+  you can leverage the ingress section of the Helm chart.
 
   The Helm chart allows customizing the ingress object to your needs.
-  When `enabled` is set to `true`, the chart allows you to specify optional parameters
+  When `enabled` is set to `true` (by default, `enabled` is set to `false`),
+  the chart allows you to specify optional parameters
   of host, path, pathType, tls, and annotations.
   This supports many different Ingress-Controllers and configurations.
 
-  ```console
+  ```
   helm upgrade keptn keptn --install -n keptn --create-namespace
   --set=ingress.enabled=true,
        ingress.annotations=<YOUR_ANNOTATIONS>,
@@ -72,13 +132,65 @@ helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=
        ingress.tls=<YOUR_TLS>
   ```
 
-## Install Keptn execution-plane:
+## Confirm Installation
+
+After you issue the **helm install** command,
+it takes a couple minutes for the installation to finish.
+Use the following command to watch the progress:
+
+```
+kubectl -n keptn get servers
+```
+
+Wait for all the pods in the Keptn namespace to show `Running` under the `STATUS` column
+before proceeding.
+
+Use the following command to view all the services that are installed in the Keptn namespace:
+
+```
+kubectl -n keptn get services
+```
+
+## Access the Keptn Bridge
+
+The [Keptn Bridge](../../0.18.x/bridge) is the graphical user interface
+you can use to manage and view Keptn projects running in your installation.
+To access it:
+
+1. Expose the API Gateway NGINX.  This can be done in two ways:
+
+   * Set the `apiGatewayNginx` parameter during installation
+   * Issue the following command after installation:
+     ```
+     kubectl -n kkeptn port-forward svc/api-gateway-nginx 8080:80
+     ```
+2. Open a browser window to `localhost:8080`
+
+3. Log into the Keptn Bridge.
+   The following commands give you the username and randomly-generated password
+   to use if your site uses [Basic Authentication](../../0.18.x/bridge/basic_authentication):
+
+   ```
+   kubectl -n keptn get secret bridge-credentials -o jsonpat-{.data.BASIC_AUTH_USERNAME} | base64 -d echo
+   kubectl -n keptn get secret bridge-credentials -o jsonpat-{.data.BASIC_AUTH_PASSWORD} | base64 -d echo
+   ```
+   You can also use [OpenID Authentication](../../0.18.x/bridge/oauth) to access the Keptn Bridge.
+
+## Install Execution Plane
+
+To install the Execution Plane in the same namespace as the Control Plane,
+install a microservice.
+For example, the following two commands install the Jmeter and Helm-service microservices
+and, by extension, install the Execution Plane:
 
 ```
 helm install jmeter-service https://github.com/keptn/keptn/releases/download/0.18.1/jmeter-service-0.18.1.tgz -n keptn --create-namespace --wait
 
 helm install helm-service https://github.com/keptn/keptn/releases/download/0.18.1/helm-service-0.18.1.tgz -n keptn --create-namespace --wait
 ```
+
+The Execution Plane (or multiple Execution Planes) can also be installed on different Kubernetes clusters.
+See [Multi-cluster setup](../multi-cluster) for details.
 
 ## The --set flag
 
@@ -89,16 +201,16 @@ in the [helm-charts](https://github.com/keptn/keptn/tree/master/installer/manife
 
 * The **Control Plane with the Execution Plane (for Continuous Delivery)**
 can be installed by the following command:
-```console
+```
 helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.18.1 --repo=https://charts.keptn.sh --set=continuousDelivery.enabled=true
 ```
 
 * The **Control Plane with the Execution Plane (for Continuous Delivery)** and a `LoadBalancer` for exposing Keptn can be installed by the following command:
-```console
+```
 helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.18.1 --repo=https://charts.keptn.sh --set=continuousDelivery.enabled=true,apiGatewayNginx.type=LoadBalancer
 ```
 
-### Install Keptn using a user-provided API token
+## Install Keptn using a user-provided API token
 
 You can provide your own API token for Keptn to use by setting the secret name
 in the `apiService.tokenSecretName` Helm value during installation.
@@ -109,7 +221,7 @@ The user-provided secret needs to live in the same namespace where Keptn will be
 The user-provided secret should contain a single key `keptn-api-token`
 with a token consisting of numbers and letters as its value.
 
-### Execute Helm upgrade without Internet connectivity
+## Execute Helm upgrade without Internet connectivity
 
 The following section contains instructions for installing Keptn in an air-gapped / offline installation scenario.
 
@@ -132,7 +244,7 @@ Move the Helm Charts to a directory on your local machine, e.g., `offline-keptn`
 
 For convenience, the following script creates this directory and downloads the required Helm Charts into it:
 
-```console
+```
 mkdir offline-keptn
 cd offline-keptn
 curl -L https://github.com/keptn/keptn/releases/download/0.18.1/keptn-0.18.1.tgz -o keptn-0.18.1.tgz
@@ -150,7 +262,7 @@ A helper script is provided for this in our Git repository: https://github.com/k
 
 For convenience, you can use the following commands to download and execute the script:
 
-```console
+```
 cd offline-keptn
 curl -L https://raw.githubusercontent.com/keptn/keptn/0.18.1/installer/airgapped/pull_and_retag_images.sh -o pull_and_retag_images.sh
 chmod +x pull_and_retag_images.sh
@@ -168,7 +280,7 @@ A helper script for this is provided in our Git repository: https://github.com/k
 
 For convenience, you can use the following commands to download and execute the script:
 
-```console
+```
 cd offline-keptn
 curl -L https://raw.githubusercontent.com/keptn/keptn/0.18.1/installer/airgapped/install_keptn.sh -o install_keptn.sh
 chmod +x install_keptn.sh
@@ -176,7 +288,7 @@ chmod +x install_keptn.sh
 cd ..
 ```
 
-### Install Keptn using a Root-Context
+## Install Keptn using a Root-Context
 
 The Helm Chart allows customizing the root-context for the Keptn API and Bridge.
 By default, the Keptn API is located under `http://HOSTNAME/api` and the Keptn Bridge is located under `http://HOSTNAME/bridge`.
@@ -184,15 +296,15 @@ By specifying a value for `prefixPath`, the prefix used for the root-context can
 For example, if a user sets `prefixPath=/mykeptn` in the Helm install/upgrade command,
 the Keptn API is located under `http://HOSTNAME/mykeptn/api` and the Keptn Bridge is located under `http://HOSTNAME/mykeptn/bridge`:
 
-```console
+```
 helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.18.1 --repo=https://charts.keptn.sh --set=apiGatewayNginx.type=LoadBalancer,continuousDelivery.enabled=true,prefixPath=/mykeptn
 ```
 
-### Install Keptn with externally hosted MongoDB
+## Install Keptn with externally hosted MongoDB
 
 If you want to use an externally hosted MongoDB instead of the MongoDB installed by Keptn, please use the `helm upgrade` command as shown below. Basically, provide the MongoDB host, port, user, and password in form of a connection string.
 
-```console
+```
 helm upgrade keptn keptn --install -n keptn --create-namespace
 --set=mongo.enabled=false,
       mongo.external.connectionString=<YOUR_MONGODB_CONNECTION_STRING>,

--- a/content/docs/install/helm-install/index.md
+++ b/content/docs/install/helm-install/index.md
@@ -75,7 +75,7 @@ To install the Control Plane, you must do the following:
   which implements the Kubernetes [LoadBalancer](../access/#option-1-expose-keptn-via-a-loadbalancer):**:
    ```
    helm repo add keptn https://charts.keptn.sh
-   helm install keptn keptn/keptn -nkeptn --createnamespace
+   helm install keptn keptn/keptn -n keptn --create-namespace
    kubectl -n keptn port-forward svc /api-gateway-nginx 8080:8080
    ```
    This command is useful for creating a basic Keptn installation

--- a/content/docs/install/helm-install/index.md
+++ b/content/docs/install/helm-install/index.md
@@ -162,7 +162,7 @@ To access it:
    * Set the `apiGatewayNginx` parameter during installation
    * Issue the following command after installation:
      ```
-     kubectl -n kkeptn port-forward svc/api-gateway-nginx 8080:80
+     kubectl -n keptn port-forward svc/api-gateway-nginx 8080:80
      ```
 2. Open a browser window to `localhost:8080`
 

--- a/content/docs/install/helm-install/index.md
+++ b/content/docs/install/helm-install/index.md
@@ -139,7 +139,7 @@ it takes a couple minutes for the installation to finish.
 Use the following command to watch the progress:
 
 ```
-kubectl -n keptn get servers
+kubectl -n keptn get pods
 ```
 
 Wait for all the pods in the Keptn namespace to show `Running` under the `STATUS` column

--- a/content/docs/install/multi-cluster/index.md
+++ b/content/docs/install/multi-cluster/index.md
@@ -133,9 +133,9 @@ Please find the Helm Charts here:
     Phase:          Succeeded
     ```
 
-### How to uninstall an execution plane services?
+### How to uninstall an execution plane service?
 
-* To uninstall an execution plane service, e.g., jmeter-service, just execute:
+* To uninstall an execution plane service -- in this case, the `jmeter-service`, execute:
 
     ```console
     helm uninstall jmeter-service -n keptn-exec


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

This PR is replaced by https://github.com/keptn/keptn.github.io/pull/1393 .

* Add link to @agardnerIT 's video of a simple installation
* Update and sync docs with video.  Two goals:
   1. Ensure that the video and doc do not contradict each other.  Docs have far more info than video and that is fine, just do not want contradictions
   2. Ensure that all commands used in the video are in the docs for easy copy/paste

Additional work is needed for these pages, including:
* Revise/rework instructions beyond Control Plane installation.  I changed the header levels of these sections to correct the structure but did not revise contents.
* Improve flow between this page and multi-cluster.  This includes using the explanation of Control Plane and Execution Plane that is currently in multi-cluster into helm-service and perhaps removing instructions for installing Control Plane from the multi-cluster page since I think that process is exactly the same.
* Reference values.yaml reference page when it is merged and discuss modifying that file along with info about the --set flag

https://github.com/keptn/keptn.github.io/issues/1370 