### PR TITLE
fix: Fixed broken link to automatic provisioning Helm value

### DIFF
--- a/content/docs/0.17.x/api/git_provisioning/index.md
+++ b/content/docs/0.17.x/api/git_provisioning/index.md
@@ -16,7 +16,7 @@ When a project is created, Keptn performs a call to the service that adheres to 
 Keptn calls the service that implements such interface passing the project name and the namespace in which Keptn is currently running. The service is expected to answer with the URL, username, and token to access the repository. Keptn uses this information to configure the upstream repository for the project.
 Similarly, when a project is deleted, Keptn calls the service implementing such an API. This can be used to deprovision the repository and perform clean up actions.
 
-This feature is enabled via the Helm value [`control-plane.features.automaticProvisioningURL`](https://github.com/keptn/keptn/blob/0.17.0/installer/manifests/keptn/charts/control-plane/values.yaml#L26). This value must contain the base URL of the service that implements the interface.
+This feature is enabled via the Helm value [`features.automaticProvisioning.serviceURL`](https://github.com/keptn/keptn/blob/0.17.0/installer/manifests/keptn/values.yaml#L36). This value must contain the base URL of the service that implements the interface.
 
 ---
 

--- a/content/docs/0.18.x/api/git_provisioning/index.md
+++ b/content/docs/0.18.x/api/git_provisioning/index.md
@@ -16,7 +16,7 @@ When a project is created, Keptn performs a call to the service that adheres to 
 Keptn calls the service that implements such interface passing the project name and the namespace in which Keptn is currently running. The service is expected to answer with the URL, username, and token to access the repository. Keptn uses this information to configure the upstream repository for the project.
 Similarly, when a project is deleted, Keptn calls the service implementing such an API. This can be used to deprovision the repository and perform clean up actions.
 
-This feature is enabled via the Helm value [`control-plane.features.automaticProvisioningURL`](https://github.com/keptn/keptn/blob/0.18.0/installer/manifests/keptn/charts/control-plane/values.yaml#L26). This value must contain the base URL of the service that implements the interface.
+This feature is enabled via the Helm value [`features.automaticProvisioning.serviceURL`](https://github.com/keptn/keptn/blob/0.18.0/installer/manifests/keptn/values.yaml#L55). This value must contain the base URL of the service that implements the interface.
 
 ---
 

--- a/content/docs/0.19.x/api/git_provisioning/index.md
+++ b/content/docs/0.19.x/api/git_provisioning/index.md
@@ -16,7 +16,7 @@ When a project is created, Keptn performs a call to the service that adheres to 
 Keptn calls the service that implements such interface passing the project name and the namespace in which Keptn is currently running. The service is expected to answer with the URL, username, and token to access the repository. Keptn uses this information to configure the upstream repository for the project.
 Similarly, when a project is deleted, Keptn calls the service implementing such an API. This can be used to deprovision the repository and perform clean up actions.
 
-This feature is enabled via the Helm value [`control-plane.features.automaticProvisioningURL`](https://github.com/keptn/keptn/blob/0.19.0/installer/manifests/keptn/charts/control-plane/values.yaml#L26). This value must contain the base URL of the service that implements the interface.
+This feature is enabled via the Helm value [`features.automaticProvisioning.serviceURL`](https://github.com/keptn/keptn/blob/0.19.0/installer/manifests/keptn/values.yaml#L47). This value must contain the base URL of the service that implements the interface.
 
 ---
 


### PR DESCRIPTION
## This PR

- For 0.18 the `control-plane.features.automaticProvisioningURL` Helm value was changed to `features.automaticProvisioning.serviceURL`.

Signed-off-by: TannerGilbert <gilberttanner.work@gmail.com>