### PR TITLE
Alternate presentation of multi-cluster exec plane names

### DIFF
--- a/content/docs/0.18.x/reference/miscellaneous/distributor/index.md
+++ b/content/docs/0.18.x/reference/miscellaneous/distributor/index.md
@@ -160,15 +160,38 @@ This behavior can be changed by setting the variable `HTTP_SSL_VERIFY` to `false
 
 The remaining parameters, such as `PUBSUB_RECIPIENT`, `PUBSUB_RECIPIENT_PORT` and `PUBSUB_RECIPIENT_PATH`, as well as the `API_PROXY_PORT` can be configured as described above.
 
+**Providing a unique name for execution planes that run the same integration**
+
+If your Keptn [multi-cluster set-up](../../../../install/multi-cluster)
+includes multiple execution planes that run the same integration service,
+you must configure a unique name for each execution plane.
+By default, Keptn uses the execution plane integration name and version to identify the execution plane.
+Multiple execution planes that run the same integration service thus have the same identifier,
+so Keptn assigns the same set of event subscriptions to them all
+unless you assign a different name to each remote execution plane integration.
+
+Use the `K8S_DEPLOYMENT_NAME` environment variable on each execution plane
+to set a unique name label and distributor service name for that execution plane:
+
+```
+K8S_DEPLOYMENT_NAME: "server001-helm-server"
+```
+
+If the execution plane integration uses the Distributor to manage event subscriptions,
+(`helm-service` and `jmeter-service` are among the integrations that do),
+you can instead provide a unique name for the execution plane
+by editing the `values.yaml` on each execution plane and setting a unique value for the `nameOverride` value.
+
 ## Installation
 
 Distributors are installed automatically as a part of [Keptn](https://keptn.sh).
 
 ## Deploy in your Kubernetes cluster
 
-To deploy the current version of a *distributor* in your Keptn Kubernetes cluster, use the file `deploy/distributor.yaml` from this repository and apply it:
+To deploy the current version of a *distributor* in your Keptn Kubernetes cluster,
+apply the [deploy/distributor.yaml](../../files/distributor) file from this repository:
 
-```console
+```
 kubectl apply -f deploy/service.yaml
 ```
 
@@ -176,7 +199,7 @@ kubectl apply -f deploy/service.yaml
 
 To delete a deployed *distributor*, use the file `deploy/distributor.yaml` from this repository and delete the Kubernetes resources:
 
-```console
+```
 kubectl delete -f deploy/service.yaml
 ```
 

--- a/content/docs/0.18.x/reference/miscellaneous/distributor/index.md
+++ b/content/docs/0.18.x/reference/miscellaneous/distributor/index.md
@@ -70,7 +70,7 @@ The following environment variables filter events:
 - `STAGE_FILTER` - Filter events for a specific stage. default = `""`, supports a comma-separated list of stages.
 - `SERVICE_FILTER` - Filter events for a specific service. default = `""`, supports a comma-separated list of services.
 
-The following 
+The following environment variables configure how the distributor identifies specific integrations:
 
 - `DISABLE_REGISTRATION` - Disables automatic registration of the Keptn integration to the control plane.
 default = `false`
@@ -81,8 +81,11 @@ default =`10s`
 - `VERSION` - The version of the Keptn integration. default = `""`
 - `K8S_DEPLOYMENT_NAME` - Kubernetes deployment name of the Keptn integration. default = `""`
 - `K8S_POD_NAME` -  Kubernetes deployment name of the Keptn integration. default = `""`
-- `K8S_NAMESPACE` - Kubernetes namespace of the Keptn integration. default = `""`
-- `K8S_NODE_NAME` - Kubernetes node name the Keptn integration is running on. default = `""`
+- `K8S_NAMESPACE` - Kubernetes namespace of the Keptn integration,
+  which is `keptn-exec` for the Execution Plane. default = `""`
+
+The following environment variables configure the Oauth Client Credentials:
+
 - `OAUTH_CLIENT_ID` - OAuth client ID used when performing Oauth Client Credentials Flow. default = `""`
 - `OAUTH_CLIENT_SECRET` - OAuth client ID used when performing Oauth Client Credentials Flow. default = `""`
 - `OAUTH_DISCOVERY` - Discovery URL called by the distributor to obtain further information for the OAuth Client Credentials Flow, e.g. the token URL. default = `""`
@@ -177,10 +180,15 @@ to set a unique name label and distributor service name for that execution plane
 K8S_DEPLOYMENT_NAME: "server001-helm-server"
 ```
 
-If the execution plane integration uses the Distributor to manage event subscriptions,
-(`helm-service` and `jmeter-service` are among the integrations that do),
-you can instead provide a unique name for the execution plane
+Each integration that uses the distibutor must properly configure the value of `K8S_DEPLOYMENT_NAME`.
+Some integrations, including `helm-service` and `jmeter-service`,
+configure this value based on the value of the `app.kubernetes.io/name` Kubernetes label;
+for example, see the [Jmeter deployment.yaml](https://github.com/keptn/keptn/blob/master/jmeter-service/chart/templates/deployment.yaml#L105) file.
+For these integrations, you can provide a unique name for the execution plane
 by editing the `values.yaml` on each execution plane and setting a unique value for the `nameOverride` value.
+Note that, if the `nameOverride` value is set to a different value
+than the `K8S_DEPLOYMENT_NAME` environment variable,
+`K8S_DEPLOYMENT_NAME` takes precedence.
 
 ## Installation
 
@@ -206,6 +214,22 @@ kubectl delete -f deploy/service.yaml
 ## Usage notes
 
 ## Differences between versions
+
+* Keptn release 0.15.x and earlier supported the
+  `K8S_NODE_NAME` environment variable to define
+  the Kubernetes node name on which the Keptn integration runs.
+  Using this variable in conjunction with `K8S_DEPLOYMENT_NAME` and `K8S_NAMESPACE`
+  allowed Keptn to differentiate between instances of the same integration
+  that ran on different execution planes
+  so it was not necessary to manually set the value of `K8S_DEPLOYMENT_NAME`.
+  For Keptn release 0.16.x and later,
+  each integration is now uniquely defined by just two parameters:
+  `K8S_DEPLOYMENT_NAME` (which is a string such as `helm-service` or `jmeter-service` unless modified)
+  and `K8S_NAMESPACE` (which is `keptn-exec`),
+  so the `K8S_DEPLOYMENT_NAME` environment variable must be explicitly set to a unique value
+  on each execution plane
+  so that all instances of the integration are listed separately on the integrations page in the Keptn Bridge
+  and so that events for that integration are only delivered to the appropriate execution plane.
 
 * In Keptn Release 0.14.x, the NATS dependency is upgraded.
 Because of this, the NATS cluster name is now `keptn-nats`

--- a/content/docs/install/multi-cluster/index.md
+++ b/content/docs/install/multi-cluster/index.md
@@ -88,6 +88,35 @@ Please find the Helm Charts here:
         token: ""                           # < (5) set Keptn API token
     ```
 
+* If your cluster includes multiple execution planes that run the same integration service,
+  you must configure a unique name for each execution plane.
+  By default, Keptn uses the execution plane service name and version to identify the execution plane.
+  Multiple execution planes that run the same integration service thus have the same identifier,
+  so Keptn assigns the same set of event subscriptions to them all
+  unless you assign a different name to each remote execution plane service.
+
+  You can assign a unique name label and distributor service name for the execution plane
+  in either of the following ways:
+
+  * If the execution plane integration uses the Distributor to manage event subscriptions,
+    (`helm-service` and `jmeter-service` are among the integrations that do),
+    edit the `values.yaml` on each execution plane and set a unique value for the `nameOverride` value.
+    For example:
+
+    ```
+    distributor:
+      nameOverride: "server001-helm-server"
+    ```
+
+  * Set the `K8S_DEPLOYMENT_NAME` environment variable on each execution plane to a unique name.
+    See the [distributor](../../0.18.x/reference/miscellaneous/distributor) reference page
+    for more information about the environment variables that configure the distributor.
+    For example:
+
+    ```
+    K8S_DEPLOYMENT_NAME: "server001-helm-server"
+    ```
+
 * Depending on your setup of the multi-cluster environment and the approach you modeled your staging process, one stage can be for example on a separate cluster. Let's assume the following setup: 
 
   * Project: `sockshop`
@@ -149,19 +178,19 @@ See the configuration parameters of the supported execution plane services:
 
   - `jmeter-service`: [Helm Chart values](https://github.com/keptn/keptn/blob/0.18.1/jmeter-service/chart/README.md#configuration)
 
-The important once that are used in the above example are:
+The important ones that are used in the above example are:
 
 | Parameter                | Description             | Default        |
 | ------------------------ | ----------------------- | -------------- |
-| `distributor.stageFilter` | Sets the stage this service belongs to | `""` |
-| `distributor.serviceFilter` | Sets the service this service belongs to | `""` |
-| `distributor.projectFilter` | Sets the project this service belongs to | `""` |
+| `distributor.stageFilter` | Sets the stage to which this service | `""` |
+| `distributor.serviceFilter` | Sets the service to which this service | `""` |
+| `distributor.projectFilter` | Sets the project to which this service | `""` |
 | `remoteControlPlane.enabled` | Enables remote execution plane mode | `false` |
 | `remoteControlPlane.api.protocol` | Used protocol (http, https) | `"https"` |
 | `remoteControlPlane.api.hostname` | Hostname of the control plane cluster (and port) | `""` |
 | `remoteControlPlane.api.apiValidateTls` | Defines if the control plane certificate should be validated | `true` |
 | `remoteControlPlane.api.token` | Keptn API token | `""` |
-
+| `nameOverride` | Sets a unique name for this execution plane | `""` |
 
 ## Troubleshooting
 
@@ -180,26 +209,26 @@ If you see in the Keptn Bridge that an event was triggered but no service was re
 
 * Connect you to the cluster where the execution plane is running
 
-* For example, you want to test `jmeter-service` that is running in `keptn-exec` namespace, execute:
+* For example, to test `jmeter-service` that is running in the `keptn-exec` namespace, execute:
 
-  ```console
-helm test jmeter-service -n keptn-exec
+  ```
+  helm test jmeter-service -n keptn-exec
   ```
 
-* The expected outcome should be:
+* The expected outcome is:
 
-  ```console
-Pod jmeter-service-test-api-connection pending
-Pod jmeter-service-test-api-connection succeeded
-NAME: jmeter-service
-LAST DEPLOYED: Thu Feb 25 15:55:24 2021
-NAMESPACE: keptn-exec
-STATUS: deployed
-REVISION: 1
-TEST SUITE:     jmeter-service-test-api-connection
-Last Started:   Thu Feb 25 15:55:40 2021
-Last Completed: Thu Feb 25 15:55:42 2021
-Phase:          Succeeded
+  ```
+  Pod jmeter-service-test-api-connection pending
+  Pod jmeter-service-test-api-connection succeeded
+  NAME: jmeter-service
+  LAST DEPLOYED: Thu Feb 25 15:55:24 2022
+  NAMESPACE: keptn-exec
+  STATUS: deployed
+  REVISION: 1
+  TEST SUITE:     jmeter-service-test-api-connection
+  Last Started:   Thu Feb 25 15:55:40 2022
+  Last Completed: Thu Feb 25 15:55:42 2022
+  Phase:          Succeeded
   ```
 
 **Help:**

--- a/content/docs/install/multi-cluster/index.md
+++ b/content/docs/install/multi-cluster/index.md
@@ -92,29 +92,31 @@ Please find the Helm Charts here:
   you must configure a unique name for each execution plane.
   By default, Keptn uses the execution plane service name and version to identify the execution plane.
   Multiple execution planes that run the same integration service thus have the same identifier,
-  so Keptn assigns the same set of event subscriptions to them all
+  so only one instance of the integration service is displayed on the integration page in the Bridge
+  and Keptn assigns the same set of event subscriptions to them all
   unless you assign a different name to each remote execution plane service.
 
   You can assign a unique name label and distributor service name for the execution plane
   in either of the following ways:
 
-  * If the execution plane integration uses the Distributor to manage event subscriptions,
-    (`helm-service` and `jmeter-service` are among the integrations that do),
-    edit the `values.yaml` on each execution plane and set a unique value for the `nameOverride` value.
-    For example:
-
-    ```
-    distributor:
-      nameOverride: "server001-helm-server"
-    ```
-
   * Set the `K8S_DEPLOYMENT_NAME` environment variable on each execution plane to a unique name.
     See the [distributor](../../0.18.x/reference/miscellaneous/distributor) reference page
-    for more information about the environment variables that configure the distributor.
+    for more information about this and other environment variables that configure the distributor.
     For example:
 
     ```
     K8S_DEPLOYMENT_NAME: "server001-helm-server"
+    ```
+
+  * Some integrations (such as `helm-service` and `jmeter`
+    can configure the `K8S_DEPLOYMENT_NAME` value
+    based on the value of the `app.kubernetes.io/name` Kubernetes label.
+    For these integrations, you can edit the `values.yaml` on each execution plane
+    and set a unique value for the `nameOverride` value.
+    For example:
+
+    ```
+    nameOverride: "server001-helm-server"
     ```
 
 * Depending on your setup of the multi-cluster environment and the approach you modeled your staging process, one stage can be for example on a separate cluster. Let's assume the following setup: 
@@ -252,3 +254,25 @@ remoteControlPlane:
   - Is the Keptn API token correct? (You can find it in the Keptn Bridge, or by following the guide for [authenticating](../authenticate-cli-bridge)
 
 </p></details>
+
+### Keptn sees only one instance of an integration deployed on multiple execution planes
+
+The same integration service can be deployed to multiple execution planes in your Keptn installation.
+For example, you might deploy the `helm-services` integration
+to the execution plane that runs the `dev` stage as well as the execution plane that runs the `prod` stage.
+However, you must explicitly configure each execution plane name as described above
+so that Keptn can differentiate the two instances of the integration.
+
+If you do not correctly configure the execution plane names,
+you will see two issues:
+
+* Only one instance of the integration (such as `helm-service`)
+is displayed on the integration page in the Keptn Bridge.
+* All events for that integration are delivered to all execution planes that run the service,
+so that the execution plane for the `dev` stage
+also receives events intended for the `prod` stage.
+
+To correct this situation, follow the instructions above
+to set a unique name label and distributor service name for each execution plane
+that runs this integration service.
+


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

This is an alternative presentation to https://github.com/keptn/keptn.github.io/pull/1382 , which fixes https://github.com/keptn/keptn/issues/8576 .  It makes adjusting the exec plane name a step in the process of implementing a multi-cluster environment rather than an afterthought.

The original draft had the following issues.  Giovanni responded and I believe these are fixed:
* I made up the examples without much knowledge -- please suggest better examples
* The text says that this is so the distributor can handle event subscriptions correctly, then says that the nameOverride value is available only if the integration uses the distributor.  This does not sound right.
* What happens if someone sets different values for nameOverride and K8S_DEPLOYMENT_NAME?  
* Should we add something to the Troubleshooting section to describe but it looks like if you don't handle the exec plan names correctly?

Once we get the text correct here, we need to implement these changes in the 0.19.x tree as well.