### PR TITLE
Hide version 0.13, 0.14, and 0.15

### DIFF
--- a/content/docs/0.13.x/_index.md
+++ b/content/docs/0.13.x/_index.md
@@ -4,6 +4,7 @@ linktitle: Release 0.13.x
 weight: 983
 sidebar_multicard: true
 icon: docs
+hide: true
 aliases:
   - /docs/0.13.0/
   - /docs/0.13.1/

--- a/content/docs/0.14.x/_index.md
+++ b/content/docs/0.14.x/_index.md
@@ -4,7 +4,7 @@ linktitle: Release 0.14.x
 weight: 982
 sidebar_multicard: true
 icon: docs
-hide: false
+hide: true
 aliases:
   - /docs/0.14.0/
   - /docs/0.14.1/

--- a/content/docs/0.15.x/_index.md
+++ b/content/docs/0.15.x/_index.md
@@ -4,6 +4,7 @@ linktitle: Release 0.15.x
 weight: 981
 sidebar_multicard: true
 icon: docs
+hide: true
 aliases:
   - /docs/0.15.0/
 ---


### PR DESCRIPTION
With a release date in May, version 0.15 and older when out of the 3-months window to not officially display it in the keptn/docs anymore. 

Signed-off-by: Johannes Bräuer <johannes.braeuer@gmx.at>