### PR TITLE
 Marked 0.12, 0.13, 0.14, and 0.15 as unsupported and 0.19 under development

### DIFF
--- a/content/docs/0.12.x/_index.md
+++ b/content/docs/0.12.x/_index.md
@@ -5,6 +5,7 @@ weight: 984
 sidebar_multicard: true
 icon: docs
 hide: true
+unsupported: This documentation is for an older Keptn release. Please consider the newest one when working with the latest Keptn.
 aliases:
   - /docs/0.12.0/
   - /docs/0.12.1/

--- a/content/docs/0.13.x/_index.md
+++ b/content/docs/0.13.x/_index.md
@@ -5,6 +5,7 @@ weight: 983
 sidebar_multicard: true
 icon: docs
 hide: true
+unsupported: This documentation is for an older Keptn release. Please consider the newest one when working with the latest Keptn.
 aliases:
   - /docs/0.13.0/
   - /docs/0.13.1/

--- a/content/docs/0.14.x/_index.md
+++ b/content/docs/0.14.x/_index.md
@@ -5,6 +5,7 @@ weight: 982
 sidebar_multicard: true
 icon: docs
 hide: true
+unsupported: This documentation is for an older Keptn release. Please consider the newest one when working with the latest Keptn.
 aliases:
   - /docs/0.14.0/
   - /docs/0.14.1/

--- a/content/docs/0.15.x/_index.md
+++ b/content/docs/0.15.x/_index.md
@@ -5,6 +5,7 @@ weight: 981
 sidebar_multicard: true
 icon: docs
 hide: true
+unsupported: This documentation is for an older Keptn release. Please consider the newest one when working with the latest Keptn.
 aliases:
   - /docs/0.15.0/
 ---

--- a/content/docs/0.16.x/_index.md
+++ b/content/docs/0.16.x/_index.md
@@ -5,6 +5,7 @@ weight: 980
 sidebar_multicard: true
 icon: docs
 hide: false
+unsupported: This documentation is for an older Keptn release. Please consider the newest one when working with the latest Keptn.
 aliases:
   - /docs/0.16.0/
 ---

--- a/content/docs/0.16.x/_index.md
+++ b/content/docs/0.16.x/_index.md
@@ -5,7 +5,7 @@ weight: 980
 sidebar_multicard: true
 icon: docs
 hide: false
-unsupported: This documentation is for an older Keptn release. Please consider the newest one when working with the latest Keptn.
+#unsupported: This documentation is for an older Keptn release. Please consider the newest one when working with the latest Keptn.
 aliases:
   - /docs/0.16.0/
 ---

--- a/content/docs/0.17.x/_index.md
+++ b/content/docs/0.17.x/_index.md
@@ -5,7 +5,7 @@ weight: 979
 sidebar_multicard: true
 icon: docs
 hide: false
-unsupported: This documentation is for an older Keptn release. Please consider the newest one when working with the latest Keptn.
+#unsupported: This documentation is for an older Keptn release. Please consider the newest one when working with the latest Keptn.
 aliases:
   - /docs/0.17.0/
 ---

--- a/content/docs/0.17.x/_index.md
+++ b/content/docs/0.17.x/_index.md
@@ -5,6 +5,7 @@ weight: 979
 sidebar_multicard: true
 icon: docs
 hide: false
+unsupported: This documentation is for an older Keptn release. Please consider the newest one when working with the latest Keptn.
 aliases:
   - /docs/0.17.0/
 ---

--- a/content/docs/0.19.x/_index.md
+++ b/content/docs/0.19.x/_index.md
@@ -5,6 +5,7 @@ weight: 977
 sidebar_multicard: true
 icon: docs
 hide: true
+develop: This documentation is currently under development and officially released with the next Keptn release. 
 aliases:
   - /docs/0.19.0/
 ---

--- a/content/docs/0.19.x/_index.md
+++ b/content/docs/0.19.x/_index.md
@@ -5,7 +5,7 @@ weight: 977
 sidebar_multicard: true
 icon: docs
 hide: true
-develop: This documentation is currently under development and officially released with the next Keptn release. 
+develop: This documentation is currently under development for a future Keptn release.
 aliases:
   - /docs/0.19.0/
 ---


### PR DESCRIPTION
Provide a banner that shows:
* 0.12, 0.13, 0.14, 0.15 are not supported, and
* 0.19 is under development. 

Signed-off-by: Johannes Bräuer <johannes.braeuer@gmx.at>