### PR TITLE
remove ask an expert. fixes #1392

### DIFF
--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -48,15 +48,3 @@ The [Keptn newsletter](/community/newsletter) is our way to inform the Keptn com
 ✅ Get updates on new blog posts about Keptn
 
 ✅ Hear about new Keptn integrations or announce your integration.
-
-## Ask an expert
-
-We are hosting [30 minute 1on1 sessions](https://calendly.com/jetzlstorfer/keptn) via video conference to help you get started with Keptn and answer all your questions. [Book your slot today via calendly](https://calendly.com/jetzlstorfer/keptn).
-
-✅ Talk to a Keptn expert
-
-✅ Get your questions answered on Keptn in general or on a particular feature you are interested
-
-✅ Talk about Keptn in your environment
-
-❌ This is not a good place to submit bug reports 🐞 . Please [open an issue](https://github.com/keptn/keptn/issues) instead so the Keptn maintainers & developers can take care of it.

--- a/content/home/contact-left.md
+++ b/content/home/contact-left.md
@@ -1,2 +1,1 @@
 Whether you are an end user or you want to participate in the project, we’d love to hear from you! You can find more information about how to reach us in the [Keptn community](/community) or just ping us via [Slack](https://slack.keptn.sh).
-You can even [book a 1on1 session with a Keptn expert](https://calendly.com/jetzlstorfer/keptn)!


### PR DESCRIPTION
This PR:
- Removes the "Ask an expert" section as the calendly link is no longer valid
- Thus fixes and closes #1392 

Signed-off-by: agardnerit <adam@agardner.net>