### PR TITLE
Move service page to "Manage" section

### DIFF
--- a/content/docs/0.19.x/define/delivery_sequence/index.md
+++ b/content/docs/0.19.x/define/delivery_sequence/index.md
@@ -121,7 +121,7 @@ After declaring the delivery for a project in a shipyard, you are ready to creat
 
 ## Trigger a multi-stage delivery
 
-After creating a project and creating your [service(s)](../service), you can trigger a delivery using the Keptn CLI or API.
+After creating a project and creating your [service(s)](../../manage/service), you can trigger a delivery using the Keptn CLI or API.
 
 <details><summary>**Trigger via Keptn CLI**</summary>
 <p>

--- a/content/docs/0.19.x/define/quality-gates/index.md
+++ b/content/docs/0.19.x/define/quality-gates/index.md
@@ -15,7 +15,7 @@ see the [SLO](../../reference/files/slo) reference page.
 ## Definition of project, stage, and service
 
 Let's assume you have an application that is running in an environment and composed of one or multiple services (aka. microservices). For example, you have an application called `easyBooking`, which can be broken down into the `booking` and `payment` service. Besides, the application is running in a `quality_assurance` environment (aka. stage).
-In order to manage your application and services in Keptn, you need a Keptn [project, stage](../../manage/project/) and [services](../service).
+In order to manage your application and services in Keptn, you need a Keptn [project, stage](../../manage/project/) and [services](../../manage/service).
 For the `easyBooking` application, the Keptn entities of a project, stage, and service map to the example as follows:
 
 * `project`: *easyBooking*
@@ -65,7 +65,7 @@ as discussed in [Create a project](../../manage/project).
 
 * To create the Keptn service `booking`,
 use the [keptn create service](../../reference/cli/commands/keptn_create_service/) command
-as discussed in [Create a service](../service/#create-a-service).
+as discussed in [Create a service](../../manage/service/).
 
 **Note:** It is not necessary to create the stage since it is declared in the Shipyard that is applied during the project creation.
 

--- a/content/docs/0.19.x/manage/plan/index.md
+++ b/content/docs/0.19.x/manage/plan/index.md
@@ -113,7 +113,7 @@ Absolute and relative results can be combined into a `total_score` for the evalu
 See [SLO](../../reference/files/slo) for more details.
 * What service will you use to deploy your artifact for quality gates evaluation?
 The most common choice is `helm-service`.
-See [Deploying Services](../../define/service) for more information.
+See [Create a service](../service) for more information.
 * Will you pass your artifact to the next stage
 (for example, from testing to hardening or from staging to production)
 automatically if the SLO results meet the specified goals

--- a/content/docs/0.19.x/manage/service/index.md
+++ b/content/docs/0.19.x/manage/service/index.md
@@ -1,30 +1,55 @@
 ---
-title: Service
-description: Create a service in Keptn.
-weight: 130
+title: Create a service
+description: Create a service for your project
+weight: 23
 keywords: [0.19.x-manage]
 aliases:
 ---
 
-After creating a project, Keptn allows creating a service into Keptn. 
+After creating a project, you can create one or more services for that project.
+A service spans stages in your project,
+so Keptn can run sequences for a particular microservice in different stages,
+applying different configurations to different stages.
 
 ## Service name restrictions
 
-* Service name must be a valid unix directory name (*Note*: for each service a directory with the corresponding name is created in the upstream git repository)
-* Keptn Version >= 0.8.3:
-  Service name must be less than 43 characters (*Note*: template was reduced to `${SERVICE}-generated` to allow longer service names)
+* The service name must be a a string that can be a valid *nix directory name
+because the service name is used as the name of the directory that is created in the upstream git repository.
+* The service name must be less than 43 characters long.
 
 ## Create a service
 
-* To create a service, use the [keptn create service](../../reference/cli/commands/keptn_create_service) command and provide the service and project name (`--project` flag): 
+You can create a service for your project in either of the following ways:
 
-```console
-keptn create service SERVICENAME --project=PROJECTNAME
+* Use the Keptn Bridge UI
+* Use the Keptn CLI
+
+In both cases, you must specify the service and project names.
+
+### Use the Keptn Bridge
+
+To create a service from the Keptn Bridge:
+
+1. Click on the "Services" button for your project.
+1. Click "Create service".
+1. Give your service a name.
+1. Click "Create service".
+
+### Use the Keptn CLI
+
+Use the [keptn create service](../../reference/cli/commands/keptn_create_service) command
+to create a service from the command line.
+You must [install](../../install/cli-install) and [authenticate](../../install/authenticate-cli-bridge)
+the Keptn CLI before you can run this command:
+
+```
+keptn create service <SERVICENAME> --project=<PROJECTNAME>
 ```
 
-**Requirements for the Helm Chart to deploy**
+## Requirements for the Helm Chart to deploy
 
-After creating a service, you need to provide a Helm Chart where the service deploys. For Keptn, the [Helm Chart](https://Helm.sh/) has the following requirements:
+After creating a service, you ,must provide a Helm Chart where the service deploys.
+For Keptn, the [Helm Chart](https://Helm.sh/) has the following requirements:
 
 1. The Helm chart _must_ contain exactly one [deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/). The properties `spec.selector.matchLabels.app` and `spec.template.metadata.labels.app` must be set in this deployment.
 
@@ -32,12 +57,12 @@ After creating a service, you need to provide a Helm Chart where the service dep
 
 1. The Helm chart _must_ contain a `values.yaml` file with at least the `image` and `replicaCount` parameter for the deployment. These `image` and `replicaCount` parameters must be used in the deployment. An example is shown below:
 
-  ```yaml
+  ```
   image: docker.io/keptnexamples/carts:0.13.1
   replicaCount: 1
   ```
 
-  ```yaml
+  ```
   --- 
   apiVersion: apps/v1
   kind: Deployment
@@ -60,7 +85,7 @@ After creating a service, you need to provide a Helm Chart where the service dep
 
 **Note:** If you are using custom configurations and you would like to have the environment variables `KEPTN_PROJECT`, `KEPTN_STAGE`, and `KEPTN_SERVICE` within your service, add the following environment variables to your deployment configuration.
 
-```yaml
+```
 env:
 ...
 - name: KEPTN_PROJECT
@@ -75,6 +100,6 @@ env:
 
 * Finally, upload the Helm Chart to your service: 
 
-```console
+```
 keptn add-resource --project=PROJECTNAME --service=SERVICENAME --all-stages --resource=HELM_CHART.tgz --resourceUri=helm/SERVICENAME.tgz
 ```

--- a/content/docs/0.19.x/manage/service/index.md
+++ b/content/docs/0.19.x/manage/service/index.md
@@ -39,7 +39,7 @@ To create a service from the Keptn Bridge:
 
 Use the [keptn create service](../../reference/cli/commands/keptn_create_service) command
 to create a service from the command line.
-You must [install](../../install/cli-install) and [authenticate](../../install/authenticate-cli-bridge)
+You must [install](../../../install/cli-install) and [authenticate](../../../install/authenticate-cli-bridge)
 the Keptn CLI before you can run this command:
 
 ```

--- a/content/docs/0.19.x/reference/files/shipyard/index.md
+++ b/content/docs/0.19.x/reference/files/shipyard/index.md
@@ -80,7 +80,7 @@ Each *shipyard* file must have at least one `stage`.
 The name of the stage becomes the name of the branch
 in the [upstream Git repository](../../../manage/git_upstream)
 and the Kubernetes namespace to which
-[services](../../../define/service) are deployed.
+[services](../../../manage/service) are deployed.
 
 A stage can be given any meaningful name that conforms to the
 [Kubernetes Object Names and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/)


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

* Move the "Create service" page to "Manage" section
* Add instructions for creating a service from the Keptn Bridge.  I will link Adam's "Create project and service video" to that section after it is moved to the Keptn youtube area.  I want to get this PR merged quickly so I can reference it from other docs.
* A few minor edits