### PR TITLE
xrefs to keptn-contrib for helm-service & jmeter-service

### DIFF
--- a/content/docs/0.18.x/reference/miscellaneous/distributor/index.md
+++ b/content/docs/0.18.x/reference/miscellaneous/distributor/index.md
@@ -183,7 +183,7 @@ K8S_DEPLOYMENT_NAME: "server001-helm-server"
 Each integration that uses the distibutor must properly configure the value of `K8S_DEPLOYMENT_NAME`.
 Some integrations, including `helm-service` and `jmeter-service`,
 configure this value based on the value of the `app.kubernetes.io/name` Kubernetes label;
-for example, see the [Jmeter deployment.yaml](https://github.com/keptn/keptn/blob/master/jmeter-service/chart/templates/deployment.yaml#L105) file.
+for example, see the [Jmeter deployment.yaml](https://github.com/keptn-contrib/jmeter-service/blob/main/chart/templates/deployment.yaml#L105) file.
 For these integrations, you can provide a unique name for the execution plane
 by editing the `values.yaml` on each execution plane and setting a unique value for the `nameOverride` value.
 Note that, if the `nameOverride` value is set to a different value

--- a/content/docs/0.19.x/reference/files/values/index.md
+++ b/content/docs/0.19.x/reference/files/values/index.md
@@ -27,7 +27,7 @@ so can be used to temporarily override a value when necessary.
 
 ## Files
 
-* Default [values.yaml](https://github.com/keptn/keptn/blob/master/helm-service/chart/values.yaml#L10) file: 
+* Default [values.yaml](https://github.com/keptn-contrib/helm-service/blob/main/chart/values.yaml) file: 
 
 ## Differences between versions
 


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

Fixes broken xrefs to helm-service and jmeter-service, which are now in keptn-contrib