### PR TITLE
fix: Added aliases for version check documentation starting 0.14.x

### DIFF
--- a/content/docs/0.14.x/bridge/version_check/index.md
+++ b/content/docs/0.14.x/bridge/version_check/index.md
@@ -2,6 +2,8 @@
 title: Daily Version Check
 description: Enable/Disable daily version check feature
 weight: 40
+aliases:
+  - /docs/0.14.x/reference/version_check/
 ---
 
 The feature of a daily version check informs a Keptn user in the Keptn Bridge about:

--- a/content/docs/0.15.x/bridge/version_check/index.md
+++ b/content/docs/0.15.x/bridge/version_check/index.md
@@ -2,6 +2,8 @@
 title: Daily Version Check
 description: Enable/Disable daily version check feature
 weight: 40
+aliases:
+  - /docs/0.15.x/reference/version_check/
 ---
 
 The feature of a daily version check informs a Keptn user in the Keptn Bridge about:

--- a/content/docs/0.16.x/bridge/version_check/index.md
+++ b/content/docs/0.16.x/bridge/version_check/index.md
@@ -2,6 +2,8 @@
 title: Daily Version Check
 description: Enable/Disable daily version check feature
 weight: 40
+aliases:
+  - /docs/0.16.x/reference/version_check/
 ---
 
 The feature of a daily version check informs a Keptn user in the Keptn Bridge about:

--- a/content/docs/0.17.x/bridge/version_check/index.md
+++ b/content/docs/0.17.x/bridge/version_check/index.md
@@ -2,6 +2,8 @@
 title: Daily Version Check
 description: Enable/Disable daily version check feature
 weight: 40
+aliases:
+  - /docs/0.17.x/reference/version_check/
 ---
 
 The feature of a daily version check informs a Keptn user in the Keptn Bridge about:

--- a/content/docs/0.18.x/bridge/version_check/index.md
+++ b/content/docs/0.18.x/bridge/version_check/index.md
@@ -2,6 +2,8 @@
 title: Daily Version Check
 description: Enable/Disable daily version check feature
 weight: 40
+aliases:
+  - /docs/0.18.x/reference/version_check/
 ---
 
 The feature of a daily version check informs a Keptn user in the Keptn Bridge about:

--- a/content/docs/0.19.x/bridge/version_check/index.md
+++ b/content/docs/0.19.x/bridge/version_check/index.md
@@ -2,6 +2,8 @@
 title: Daily Version Check
 description: Enable/Disable daily version check feature
 weight: 40
+aliases:
+  - /docs/0.19.x/reference/version_check/
 ---
 
 The feature of a daily version check informs a Keptn user in the Keptn Bridge about:


### PR DESCRIPTION
## This PR

- Fixes broken link on Keptn Bridge starting Keptn 0.14.x by adding an alias to version check documentation.

### Related Issues

Resolves #1411

Signed-off-by: TannerGilbert <gilberttanner.work@gmail.com>