### PR TITLE
How to use different SLI environments for different projects/services/stages

### DIFF
--- a/content/docs/0.19.x/reference/files/sli/index.md
+++ b/content/docs/0.19.x/reference/files/sli/index.md
@@ -75,7 +75,7 @@ use the [keptn add-resource](../../cli/commands/keptn_add-resource) command:
 
 **Example of multiple SLI configurations:**
 
-* Let's assume, we add the following SLI configurations to a project, stage, and service: 
+* Let's assume we add the following SLI configurations to a project, stage, and service: 
 
     * SLI configuration on project-level:
 
@@ -118,7 +118,7 @@ use the [keptn add-resource](../../cli/commands/keptn_add-resource) command:
     ```
 ## Using different SLI environments
 
-Different projects, stages, and services can utilize different environments for your SLI.
+Different projects, stages, and services within stages can utilize different environments for your SLI.
 To do this, you create different configuration files for your SLI
 and have each point to a unique secret that contains the API endpoint for your SLI
 and a token.
@@ -129,28 +129,23 @@ Consult the documentation for your SLI for the specifics.
 
 Each SLI has a configuration file;
 for Dynatrace, it is [dynatrace.conf.yaml](https://github.com/keptn-contrib/dynatrace-service/blob/master/documentation/dynatrace-conf-yaml-file.md).
-This must be specified on the project level as the default configuration for the project.
-You can create multiple versions of this file to use different environments for different projects.
-such as `dynatrace.conf_project1.yaml` and `dynatrace.conf_project2.yaml`.
-All project-level files should be located in the same directory
-as the default `dynatrace/dynatrace.conf.yaml` file.
-
-You can also create separate configuration files for different services and different stages.
-The service first looks for a configuration on the service level,
-then at the stage level, and finally at the project level if no other configurations are found.
-So, to use different SLI environments for different stages,
-you might have files named `dynatrace.conf_dev.yaml` and `dynatrace.conf_qa.yaml`,
-also colocated with the default project configuration.
-
+You can create multiple versions of this file to use different environments
+for different projects, stages, and services
+by locating a version of the file in the appropriate directory in your upstream Git repo.
+For example, if your project has the `dev`, `qa` and `prod` stages,
+you could create a unique `dynatrace.conf.yaml` file in each of these directories on Git.
 Within each file, modify the value for the API credentials secret name;
 for Dynatrace, this is the `dtCreds` field.
 
+The service first looks for a configuration on the service level,
+then at the stage level, and finally at the project level if no other configurations are found.
 
 ## See also
 
 * [slo](../slo)
 
 * [Dynatrace](https://artifacthub.io/packages/keptn/keptn-integrations/dynatrace-service)
+  * [Configuring the dynatrace-service with dynatrace/dynatrace.conf.yaml](https://github.com/keptn-contrib/dynatrace-service/blob/master/documentation/dynatrace-conf-yaml-file.md#customizing-the-conf[…]ptn-stage-or-service)
 
 * [Prometheus](https://artifacthub.io/packages/keptn/keptn-integrations/prometheus-service)
 

--- a/content/docs/0.19.x/reference/files/sli/index.md
+++ b/content/docs/0.19.x/reference/files/sli/index.md
@@ -116,6 +116,35 @@ use the [keptn add-resource](../../cli/commands/keptn_add-resource) command:
       response_time_p99: "query D-3"  # SLI from service-level overrides SLI from stage-level
       sql-statements: "query E-3"     # SLI from service-level
     ```
+## Using different SLI environments
+
+Different projects, stages, and services can utilize different environments for your SLI.
+To do this, you create different configuration files for your SLI
+and have each point to a unique secret that contains the API endpoint for your SLI
+and a token.
+
+The implementation specifics are different for each SLI provider.
+As an example, we explain how to do this when using Dynatrace.
+Consult the documentation for your SLI for the specifics.
+
+Each SLI has a configuration file;
+for Dynatrace, it is [dynatrace.conf.yaml](https://github.com/keptn-contrib/dynatrace-service/blob/master/documentation/dynatrace-conf-yaml-file.md).
+This must be specified on the project level as the default configuration for the project.
+You can create multiple versions of this file to use different environments for different projects.
+such as `dynatrace.conf_project1.yaml` and `dynatrace.conf_project2.yaml`.
+All project-level files should be located in the same directory
+as the default `dynatrace/dynatrace.conf.yaml` file.
+
+You can also create separate configuration files for different services and different stages.
+The service first looks for a configuration on the service level,
+then at the stage level, and finally at the project level if no other configurations are found.
+So, to use different SLI environments for different stages,
+you might have files named `dynatrace.conf_dev.yaml` and `dynatrace.conf_qa.yaml`,
+also colocated with the default project configuration.
+
+Within each file, modify the value for the API credentials secret name;
+for Dynatrace, this is the `dtCreds` field.
+
 
 ## See also
 

--- a/content/docs/concepts/quality_gates/index.md
+++ b/content/docs/concepts/quality_gates/index.md
@@ -9,13 +9,14 @@ keywords: [keptn, use-cases]
 
 :bulb: *A quality gate allows conducting a deployment/release validation by ensuring that defined quality criteria are met.*
 
-Keptn quality gates provide you a *declarative way* to define quality criteria of your service. Therefore, Keptn will collect, evaluate, and score those quality criteria to decide if a new release is allowed to be promoted to the next stage or if it has to be held back.
+Keptn quality gates provide a *declarative way* to define quality criteria of your service. Keptn collects, evaluates, and scores those quality criteria to decide if a new release is allowed to be promoted to the next stage or if it must be held back.
 
 ## Keptn Quality Gate Process
 
-Keptn quality gates base on the concepts of *Service-Level Indicators (SLIs)* and *Service-Level Objectives (SLOs)*. Therefore, it is possible to declaratively describe the desired quality objective for your applications and services.
+Keptn quality gates are based on the concepts of *Service-Level Indicators (SLIs)* and *Service-Level Objectives (SLOs)*. Using these, you can declaratively describe the desired quality objective for your applications and services.
 
-1. The process of evaluating a quality gate can be triggered either via the Keptn CLI or the Keptn API. 
+1. The process of evaluating a quality gate can be triggered using
+the [Keptn Bridge](../../0.19.x/bridge), the Keptn CLI or the Keptn API. 
 1. Once triggered, Keptn fetches the [SLIs](../../0.18.x/reference/files/sli/). 
 from a data provider like Prometheus, Dynatrace, or Datadog.
 1. Keptn evaluates the SLI against the SLOs that are defined for the application or service. 
@@ -31,6 +32,10 @@ from a data provider like Prometheus, Dynatrace, or Datadog.
 A service-level indicator is a *"carefully defined quantitative measure of some aspect of the level of service that is provided"* (as defined in the [Site-Reliability Engineering Book](https://landing.google.com/sre/sre-book/chapters/service-level-objectives/)). 
 
 An example of an SLI is the *response time* (also named request latency), which is the indicator of how long it takes for a request to respond with an answer. Other prominent SLIs are *error rate* (or failure rate), and throughput. Keptn defines all SLIs in a dedicated [sli.yaml](../../0.18.x/reference/files/sli/)  file to make SLIs reusable within several quality gates.
+
+By default, SLIs are defined at the project level
+but they can also be defined for a specific stage or service within a stage.
+See the [SLI reference page](../../0.19.x/reference/files/sli) for details.
 
 ## What is a Service-Level Objective (SLO)?
 


### PR DESCRIPTION
This preserves information @grabnerandi provided to a customer question.

I tried to genericize the info while using Dynatrace as an example -- I couldn't figure out where this is in the Prometheus configuration.  And I'm not sure what I wrote is totally accurate and clear.

We probably need an example of this but maybe we should build it into a bigger sample in the "define" guide section and just link to that here.

https://github.com/keptn/keptn.github.io/issues/1396 