### PR TITLE
Add structure/coherence to "Define" section

### DIFF
--- a/content/docs/0.19.x/define/_index.md
+++ b/content/docs/0.19.x/define/_index.md
@@ -10,3 +10,45 @@ and how to implement them.
 
 For information about the "mechanics" of working with Keptn projects,
 see [Manage Keptn Projects](../manage/).
+
+Keptn is most frequently used as an orchestrator for delivery orchestration.
+You can orchestrate any sequence and leverage the built-in Keptn SLO validation.
+Keptn connects your tools and makes data-driven orchestration decisions
+without requiring you to do large amounts of custom coding..
+
+This section provides information and samples to illustrate common practices
+with the following pages:
+
+* [Tasks and sequences](task-sequence) explains the components of the
+  [shipyard](../../reference/files/shipyard) file
+  that are populated to define what Keptn orchestrates.
+
+* [A simple project](simple-project) illustrates the *shipyard* for a multi-stage project
+  with `dev`, `hardening` or `staging`, and `production` stages
+  that runs functional tests in the `hardening` stage,
+  and performance tests in the `hardening` stage.
+
+  This project uses the following capabilities:
+  * The [triggeredOn](triggers/#use-triggeredon-in-a-sequence) property
+  * The [Deployment with Helm](deployment_helm) functionality
+
+* [Delivery sequence](delivery_sequence) builds the *shipyard* for another multi-stage project
+  but it utilizes the [deployment strategies](deployment_helm) more extensively.
+
+* [Quality Gates](quality-gates) discusses how to set up a `quality-gates` stage
+  that evaluates a deployment or release using metrics from the observability platform of your choice,
+  based on criteria you define.
+
+* [Delivery Assistant](delivery_assistant) illustrates how to implement
+  a *shipyard* that has both manual and automatic delivery options,
+  depending on the results of the quality gates `evaluation`.
+
+Keptn can also be used to monitor your released software and software site
+and, if it finds problems, can be set up to "self heal" --
+in other words, to automatically take steps to remediate the problem.
+For example, it can scale your resources up or down
+or roll back the software to a previous release
+or send notifications to staff members.
+
+* [Remediation Sequence](remediation-sequence)
+  discusses how to implement automatic remediation on your site.

--- a/content/docs/0.19.x/define/delivery_assistant/index.md
+++ b/content/docs/0.19.x/define/delivery_assistant/index.md
@@ -7,7 +7,9 @@ aliases:
   - /docs/0.19.x/reference/bridge/delivery_assistent/
 ---
 
-If you would like to extend the [multi-stage delivery](../multi_stage/ with the capabilities of the delivery assistant, just add the `approval` task to a sequence in your shipyard, as shown by the example of the *delivery* sequence in the *staging* stage: 
+If you would like to extend the [delivery sequence](../delivery_sequence)
+with the capabilities of the delivery assistant, just add the `approval` task to a sequence in your shipyard,
+as shown by the example of the *delivery* sequence in the *staging* stage: 
 
 ```
 - name: "staging"

--- a/content/docs/0.19.x/define/delivery_sequence/index.md
+++ b/content/docs/0.19.x/define/delivery_sequence/index.md
@@ -1,7 +1,7 @@
 ---
 title: Delivery sequence
 description: Customize your delivery and staging process.
-weight: 50
+weight: 70
 keywords: [0.19.x-cd]
 ---
 

--- a/content/docs/0.19.x/define/quality-gates/index.md
+++ b/content/docs/0.19.x/define/quality-gates/index.md
@@ -1,7 +1,7 @@
 ---
 title: Quality Gates
 description: Implement Quality Gate evaluations in your project
-weight: 70
+weight: 50
 keywords: [0.19.x-quality_gates]
 ---
 

--- a/content/docs/0.19.x/define/simple-project/index.md
+++ b/content/docs/0.19.x/define/simple-project/index.md
@@ -1,21 +1,20 @@
 ---
-title: Define project in a shipyard
-description: Overview of using a shipyard, sequences and tasks to define a project
+title: A simple project
+description: A simple project with dev, hardening, and production stages
 weight: 30
-keywords: [0.19.x-manage]
+keywords: [0.19.x-define]
 aliases:
 ---
 
-A [shipyard.yaml](../../reference/files/shipyard) file is defined at the level of a project.
-This means that all services in a project share the same shipyard definition.
+This page walks through the process of populating
+a [shipyard](../../reference/files/shipyard) file that defines
+a simple, multi-stage project.
 
-* A shipyard defines the stages each deployment has to go through until it is released in the final stage, e.g., the production stage.
-
-* A shipyard can consist of any number of stages; but at least one. Each stage must have at least the name property.
-
-* A stage can contain any number of sequences but must have at least one.
 
 **Example of a shipyard with three stages:**
+
+This is a minimalist *shipyard* file that can be used to create the project
+as discussesd in [Start a project](../manage/project):
 
     apiVersion: spec.keptn.sh/0.2.3
     kind: "Shipyard"
@@ -26,6 +25,11 @@ This means that all services in a project share the same shipyard definition.
         - name: "dev"
         - name: "hardening"
         - name: "production"
+
+This is enough to set up the project.
+To make it do something useful, you must populate
+[tasks and sequences](task-sequence).
+These are illustrated below.
 
 **Example:** Extended shipyard with a delivery sequence in all three stage:
 

--- a/content/docs/0.19.x/define/task-sequence/index.md
+++ b/content/docs/0.19.x/define/task-sequence/index.md
@@ -1,0 +1,38 @@
+---
+title: Tasks and sequences
+description: Learn about tasks and sequences that define what your project does
+weight: 20
+keywords: [0.19.x-define]
+aliases:
+---
+
+In [Start a project](../../manage/project),
+you defined a [shipyard.yaml](../../reference/files/shipyard) file
+and used that to create your project.
+You can create a project with a *shipyard* that only has stages
+but it does not do anything until you populate `sequences` and `tasks` in those stages.
+
+* A `sequence` is an ordered list of tasks that are triggered sequentially.
+  By default, a sequence is a standalone section that runs and finishes,
+  although you can define a certain sequence to run only after another sequence completes,
+  or you can specify that it runs only if another sequence runs successfully
+  or if the other sequence fails;
+  this essentially forms a chain of sequences.
+* A single `task` is the smallest executable unit.
+Remember that, in Keptn, a `task` defines **what** to do (run a performance test
+or try to repair a problem on your site)
+but does not define **how** to do that (such as which tool to use).
+
+Sequences can be triggered in a variety of ways; see [Triggers](../triggers) for details and examples
+or watch the [Trigger a Keptn Sequence](https://www.youtube.com/watch?v=S0eumPKuAJY) video
+for a demonstration of triggering a sequence using the [Keptn Bridge](../../bridge).
+
+The [Lifecycle of a Keptn task](https://www.youtube.com/watch?v=Qtz0vi6ms3A) video
+discusses how Keptn executes tasks by issuing events.
+
+For more details about tasks and sequences,
+see the [shipyard](../../reference/files/shipyard) reference file
+
+Other pages in this section show specific examples of how to define
+sequences and tasks for various purposes.
+

--- a/content/docs/0.19.x/define/triggers/index.md
+++ b/content/docs/0.19.x/define/triggers/index.md
@@ -7,11 +7,6 @@ aliases:
 ---
 
 By default, a sequence runs as a standalone section that runs and finishes.
-You can also use the `triggeredOn` property
-in the the [shipyard](../../reference/files/shipyard)
-to specify an event that triggers this sequence,
-implicitly linking two sequences.
-
 You can manually trigger a sequence in any of the following ways,
 usually for testing and demonstration purposes:
 
@@ -19,7 +14,12 @@ usually for testing and demonstration purposes:
 * Using the Keptn API
 * Using the Keptn CLI
 
-Each of these is discussed below.
+You can also use the `triggeredOn` property
+in the the [shipyard](../../reference/files/shipyard)
+to specify an event that triggers this sequence,
+implicitly linking two sequences.
+
+Each of these mechanismsis discussed below.
 
 ## Use triggeredOn in a sequence
 


### PR DESCRIPTION
Signed-off-by: Meg McRoberts meg.mcroberts@dynatrace.com

This PR attempts to provide a bit of structure and coherence to the "Define a project" section with the following:

* Summary/intro list on landing page to provide sort of a reference learning path
* Some adjustments to the content of each individual page

This PR does not address checking the code and information to be sure it is up-to-date for current releases

This section needs major work.  Some good info but a lot of duplication/redundancy and not a lot of depth.  Each page is really just some sample shipyards without context and a list of what is required to implement the functionality or how to run it.  We need to step back to identify what is really required and what is the best way to present it -- some combination of videos and prose, perhaps pointing to existing examples, et cetera.

For now, this is all we have so this attempts to make the information a bit more accessible.