### PR TITLE
Remove references to KEP-70

### DIFF
--- a/content/docs/0.16.x/reference/files/shipyard/index.md
+++ b/content/docs/0.16.x/reference/files/shipyard/index.md
@@ -303,7 +303,7 @@ rather than on the control plane.
 A shipyard is defined at the level of a project.
 This means that all services in a project share the same shipyard definition.
 
-At this time, you can not add or delete stages in the *shipyard* file for an existing project
+You can not add or delete stages in the *shipyard* file for an existing project
 although you can make other modifications.
 See [Updating a shipyard](../../../manage/shipyard/#updating-a-shipyard)
 for information about modifications that can be made to a *shipyard* file.

--- a/content/docs/0.16.x/reference/files/shipyard/index.md
+++ b/content/docs/0.16.x/reference/files/shipyard/index.md
@@ -106,10 +106,8 @@ such as `development`, `hardening`, `staging`, or `production.
 * `sequences`: An array of sequences that define the tasks to be performed
 and, optionally, the events that trigger each task.
 
-At this time, you can not add or delete stages in the *shipyard* file for an existing project
+You can not add or delete stages in the *shipyard* file for an existing project
 although you can make other modifications.
-See [KEP-70](https://github.com/keptn/enhancement-proposals/pull/70) for details
-about the ongoing initiative to overcome this limitation.
 
 **Sequence**
 
@@ -307,10 +305,7 @@ This means that all services in a project share the same shipyard definition.
 
 At this time, you can not add or delete stages in the *shipyard* file for an existing project
 although you can make other modifications.
-
-* See [KEP-70](https://github.com/keptn/enhancement-proposals/pull/70) for details
-about the initiative to allow adding/removing stages to/from a *shipyard* file.
-* See [Updating a shipyard](../../../manage/shipyard/#updating-a-shipyard)
+See [Updating a shipyard](../../../manage/shipyard/#updating-a-shipyard)
 for information about modifications that can be made to a *shipyard* file.
 
 As a workaround, you can temporarily skip the execution of a particular stage by doing either of the following:
@@ -331,8 +326,6 @@ and  named to match the value of the `Metadata` name field in the shipyard file.
 
 ## Differences between versions
 
-* [KEP-70](https://github.com/keptn/enhancement-proposals/pull/70) is active
-to allow `stage`s to be added to and removed from a *shipyard* in an existing project.
 
 ## See also
 

--- a/content/docs/0.17.x/reference/files/shipyard/index.md
+++ b/content/docs/0.17.x/reference/files/shipyard/index.md
@@ -106,10 +106,8 @@ such as `development`, `hardening`, `staging`, or `production.
 * `sequences`: An array of sequences that define the tasks to be performed
 and, optionally, the events that trigger each task.
 
-At this time, you can not add or delete stages in the *shipyard* file for an existing project
+You can not add or delete stages in the *shipyard* file for an existing project
 although you can make other modifications.
-See [KEP-70](https://github.com/keptn/enhancement-proposals/pull/70) for details
-about the ongoing initiative to overcome this limitation.
 
 **Sequence**
 
@@ -313,10 +311,7 @@ This means that all services in a project share the same shipyard definition.
 
 At this time, you can not add or delete stages in the *shipyard* file for an existing project
 although you can make other modifications.
-
-* See [KEP-70](https://github.com/keptn/enhancement-proposals/pull/70) for details
-about the initiative to allow adding/removing stages to/from a *shipyard* file.
-* See [Updating a shipyard](../../../manage/shipyard/#updating-a-shipyard)
+See [Updating a shipyard](../../../manage/shipyard/#updating-a-shipyard)
 for information about modifications that can be made to a *shipyard* file.
 
 As a workaround, you can temporarily skip the execution of a particular stage by doing either of the following:
@@ -336,9 +331,6 @@ that contain annotated examples for accomplishing various tasks.
 and  named to match the value of the `Metadata` name field in the shipyard file.
 
 ## Differences between versions
-
-* [KEP-70](https://github.com/keptn/enhancement-proposals/pull/70) is active
-to allow `stage`s to be added to and removed from a *shipyard* in an existing project.
 
 ## See also
 

--- a/content/docs/0.18.x/manage/update/index.md
+++ b/content/docs/0.18.x/manage/update/index.md
@@ -22,10 +22,8 @@ The following updates of shipyard.yaml are currently supported by Keptn:
 * Add/Remove a task sequence to/from a stage
 * Define a trigger for a sequence 
 
-Currently, you can not add or delete stages in the *shipyard* file for an existing project
+You can not add or delete stages in the *shipyard* file for an existing project
 although you can make other modifications.
-See [KEP-70](https://github.com/keptn/enhancement-proposals/pull/70) for details
-about the ongoing initiative to overcome this limitation.
 
 **Initial shipyard**
 

--- a/content/docs/0.18.x/reference/files/shipyard/index.md
+++ b/content/docs/0.18.x/reference/files/shipyard/index.md
@@ -106,10 +106,8 @@ such as `development`, `hardening`, `staging`, or `production.
 * `sequences`: An array of sequences that define the tasks to be performed
 and, optionally, the events that trigger each task.
 
-At this time, you can not add or delete stages in the *shipyard* file for an existing project
+You can not add or delete stages in the *shipyard* file for an existing project
 although you can make other modifications.
-See [KEP-70](https://github.com/keptn/enhancement-proposals/pull/70) for details
-about the ongoing initiative to overcome this limitation.
 
 **Sequence**
 
@@ -322,11 +320,8 @@ rather than on the control plane.
 A shipyard is defined at the level of a project.
 This means that all services in a project share the same shipyard definition.
 
-At this time, you can not add or delete stages in the *shipyard* file for an existing project
+You can not add or delete stages in the *shipyard* file for an existing project
 although you can make other modifications.
-
-* See [KEP-70](https://github.com/keptn/enhancement-proposals/pull/70) for details
-about the initiative to allow adding/removing stages to/from a *shipyard* file.
 * See [Updating project's shipyard](../../../manage/update)
 for information about modifications that can be made to a *shipyard* file.
 
@@ -347,9 +342,6 @@ that contain annotated examples for accomplishing various tasks.
 and  named to match the value of the `Metadata` name field in the shipyard file.
 
 ## Differences between versions
-
-* [KEP-70](https://github.com/keptn/enhancement-proposals/pull/70) is active
-to allow `stage`s to be added to and removed from a *shipyard* in an existing project.
 
 ## See also
 

--- a/content/docs/0.19.x/manage/update/index.md
+++ b/content/docs/0.19.x/manage/update/index.md
@@ -22,10 +22,8 @@ The following updates of shipyard.yaml are currently supported by Keptn:
 * Add/Remove a task sequence to/from a stage
 * Define a trigger for a sequence 
 
-Currently, you can not add or delete stages in the *shipyard* file for an existing project
+You can not add or delete stages in the *shipyard* file for an existing project
 although you can make other modifications.
-See [KEP-70](https://github.com/keptn/enhancement-proposals/pull/70) for details
-about the ongoing initiative to overcome this limitation.
 
 **Initial shipyard**
 

--- a/content/docs/0.19.x/reference/files/shipyard/index.md
+++ b/content/docs/0.19.x/reference/files/shipyard/index.md
@@ -110,10 +110,8 @@ such as `development`, `hardening`, `staging`, or `production.
 * `sequences`: An array of sequences that define the tasks to be performed
 and, optionally, the events that trigger each task.
 
-At this time, you can not add or delete stages in the *shipyard* file for an existing project
+You can not add or delete stages in the *shipyard* file for an existing project
 although you can make other modifications.
-See [KEP-70](https://github.com/keptn/enhancement-proposals/pull/70) for details
-about the ongoing initiative to overcome this limitation.
 
 **Sequence**
 
@@ -326,12 +324,9 @@ rather than on the control plane.
 A shipyard is defined at the level of a project.
 This means that all services in a project share the same shipyard definition.
 
-At this time, you can not add or delete stages in the *shipyard* file for an existing project
+You can not add or delete stages in the *shipyard* file for an existing project
 although you can make other modifications.
-
-* See [KEP-70](https://github.com/keptn/enhancement-proposals/pull/70) for details
-about the initiative to allow adding/removing stages to/from a *shipyard* file.
-* See [Updating project's shipyard](../../../manage/update)
+See [Updating project's shipyard](../../../manage/update)
 for information about modifications that can be made to a *shipyard* file.
 
 As a workaround, you can temporarily skip the execution of a particular stage by doing either of the following:
@@ -351,9 +346,6 @@ that contain annotated examples for accomplishing various tasks.
 and  named to match the value of the `Metadata` name field in the shipyard file.
 
 ## Differences between versions
-
-* [KEP-70](https://github.com/keptn/enhancement-proposals/pull/70) is active
-to allow `stage`s to be added to and removed from a *shipyard* in an existing project.
 
 ## See also
 


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

KEP-70 to allow adding/deleting/modifying stages in a shipyard after it is created is no longer active so deleting all references to it from the docs.

https://github.com/keptn/keptn.github.io/issues/1472