### PR TITLE
Fix outdated xrefs in 0.19.x docs

### DIFF
--- a/content/docs/concepts/keptn-tools/index.md
+++ b/content/docs/concepts/keptn-tools/index.md
@@ -23,7 +23,7 @@ It allows for interoperability and any kinds of integrations in the Keptn ecosys
 
 ## Start with the shipyard
 
-Keptn's [shipyard](../../0.18.x/reference/files/shipyard) file is the blueprint for your Keptn environment.
+Keptn's [shipyard](../../0.19.x/reference/files/shipyard) file is the blueprint for your Keptn environment.
 While it may look like a pipeline, nowhere does it mention the tooling used to action each task.
 This is deliberate and by design.
 It is this factor that allows hot-swapping of tools.

--- a/content/docs/install/authenticate-cli-bridge/index.md
+++ b/content/docs/install/authenticate-cli-bridge/index.md
@@ -24,7 +24,7 @@ After [installing Keptn](../helm-install), you already have your Keptn endpoint.
 KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)
 ```
 
-* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../0.17.x/reference/cli/commands/keptn_auth) command:
+* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../0.19.x/reference/cli/commands/keptn_auth) command:
 
 ```console
 keptn auth --endpoint=$KEPTN_ENDPOINT --api-token=$KEPTN_API_TOKEN
@@ -57,7 +57,7 @@ $tokenEncoded = $(kubectl get secret keptn-api-token -n keptn -ojsonpath='{.data
 $Env:KEPTN_API_TOKEN = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($tokenEncoded))
 ```
 
-* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../0.17.x/reference/cli/commands/keptn_auth) command:
+* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../0.19.x/reference/cli/commands/keptn_auth) command:
 
 ```
 keptn auth --endpoint=$Env:KEPTN_ENDPOINT --api-token=$Env:KEPTN_API_TOKEN
@@ -101,7 +101,7 @@ certutil -decode keptn-api-token-base64.txt keptn-api-token.txt
 set KEPTN_API_TOKEN=keptn-api-token
 ```
 
-* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../0.17.x/reference/cli/commands/keptn_auth) command:
+* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../0.19.x/reference/cli/commands/keptn_auth) command:
 
 ```
 keptn.exe auth --endpoint=$Env:KEPTN_ENDPOINT --api-token=$Env:KEPTN_API_TOKEN
@@ -138,5 +138,5 @@ kubectl get secret -n keptn bridge-credentials -o jsonpath="{.data.BASIC_AUTH_PA
 ```
 
 * If you want to change the user and password for the authentication,
-follow the instructions [here](../../0.17.x/bridge/basic_authentication/#enable-authentication).
+follow the instructions [here](../../0.19.x/bridge/basic_authentication/#enable-authentication).
 

--- a/content/docs/install/cli-install/index.md
+++ b/content/docs/install/cli-install/index.md
@@ -11,11 +11,11 @@ but is instead an interface to Keptn,
 much as **kubectl** is an interface to Kubernetes.
 
 The Keptn CLI sends commands to Keptn by interacting with the Keptn API.
-The [API Token](../../0.18.x/operate/api_token)
+The [API Token](../../0.19.x/operate/api_token)
 that is used to communicate with Keptn is generated during the installation.
 
 It is not absolutely necessary to install the Keptn CLI for current Keptn releases,
-which allow you to create a project or run a sequence using the [Keptn Bridge](../../0.18.x/bridge),
+which allow you to create a project or run a sequence using the [Keptn Bridge](../../0.19.x/bridge),
 but it is recommended for production systems.
 
 You can install the Keptn CLI using:

--- a/content/docs/install/k8s/index.md
+++ b/content/docs/install/k8s/index.md
@@ -63,7 +63,7 @@ Run your Keptn installation for free on GKE! If you [sign up for a Google Cloud 
 
   - [oc CLI - v4.1](https://github.com/openshift/origin/releases/tag/v4.1.0)
 
-1. Currently, there is the *known limitation* that the MongoDB of Keptn does not start. Please follow the troubleshooting guide provided here: [MongoDB on OpenShift 4 fails](../../0.17.x/troubleshooting/#mongodb-on-openshift-4-fails).
+1. Currently, there is the *known limitation* that the MongoDB of Keptn does not start. Please follow the troubleshooting guide provided here: [MongoDB on OpenShift 4 fails](../../0.19.x/troubleshooting/#mongodb-on-openshift-4-fails).
 
 **OpenShift 3.11**
 

--- a/content/docs/install/k8s/index.md
+++ b/content/docs/install/k8s/index.md
@@ -63,7 +63,7 @@ Run your Keptn installation for free on GKE! If you [sign up for a Google Cloud 
 
   - [oc CLI - v4.1](https://github.com/openshift/origin/releases/tag/v4.1.0)
 
-1. Currently, there is the *known limitation* that the MongoDB of Keptn does not start. Please follow the troubleshooting guide provided here: [MongoDB on OpenShift 4 fails](../../0.19.x/troubleshooting/#mongodb-on-openshift-4-fails).
+1. Currently, there is the *known limitation* that the MongoDB of Keptn does not start. Please follow the troubleshooting guide provided here: [MongoDB fails on OpenShift](../../install/troubleshooting/#mongodb-fails-on-openshift).
 
 **OpenShift 3.11**
 

--- a/content/docs/install/multi-cluster/index.md
+++ b/content/docs/install/multi-cluster/index.md
@@ -64,16 +64,16 @@ In this release of Keptn, the execution plane services for deployment (`helm-ser
 
 Please find the Helm Charts here:
 
-  - `helm-service`: GitHub Release for [0.18.1](https://github.com/keptn/keptn/releases/tag/0.18.1) at **Assets** > `helm-service-0.18.1.tgz`
+  - `helm-service`: GitHub Release for [0.19.1](https://github.com/keptn/keptn/releases/tag/0.19.1) at **Assets** > `helm-service-0.19.1.tgz`
 
-  - `jmeter-service`: GitHub Release for [0.18.1](https://github.com/keptn/keptn/releases/tag/0.18.1) at **Assets** > `jmeter-service-0.18.1.tgz`
+  - `jmeter-service`: GitHub Release for [0.19.1](https://github.com/keptn/keptn/releases/tag/0.19.1) at **Assets** > `jmeter-service-0.19.1.tgz`
 
 ### How to deploy an execution plane service?
 
 * Download the `values.yaml` from the release branch, e.g., for the jmeter-service:
 
     ```
-    wget https://raw.githubusercontent.com/keptn/keptn/0.18.1/jmeter-service/chart/values.yaml
+    wget https://raw.githubusercontent.com/keptn/keptn/0.19.1/jmeter-service/chart/values.yaml
     ```
 
 * Edit the `values.yaml` to connect the services to the Keptn control plane, identified by its endpoint and API token. Therefore, set the values (1) - (5):
@@ -100,7 +100,7 @@ Please find the Helm Charts here:
   in either of the following ways:
 
   * Set the `K8S_DEPLOYMENT_NAME` environment variable on each execution plane to a unique name.
-    See the [distributor](../../0.18.x/reference/miscellaneous/distributor) reference page
+    See the [distributor](../../0.19.x/reference/miscellaneous/distributor) reference page
     for more information about this and other environment variables that configure the distributor.
     For example:
 
@@ -141,7 +141,7 @@ Please find the Helm Charts here:
 * Deploy the execution plane service (e.g., jmeter-service) from release assets with your `values.yaml` and by using `helm`:
 
     ```console
-    helm install jmeter-service https://github.com/keptn/keptn/releases/download/0.18.1/jmeter-service-0.18.1.tgz -n keptn-exec --create-namespace --values=values.yaml
+    helm install jmeter-service https://github.com/keptn/keptn/releases/download/0.19.1/jmeter-service-0.19.1.tgz -n keptn-exec --create-namespace --values=values.yaml
     ```
 
 * Test connection to Keptn control plane using:
@@ -176,9 +176,9 @@ Please find the Helm Charts here:
 
 See the configuration parameters of the supported execution plane services:
 
-  - `helm-service`: [Helm Chart values](https://github.com/keptn/keptn/blob/0.18.1/helm-service/chart/README.md#configuration)
+  - `helm-service`: [Helm Chart values](https://github.com/keptn/keptn/blob/0.19.1/helm-service/chart/README.md#configuration)
 
-  - `jmeter-service`: [Helm Chart values](https://github.com/keptn/keptn/blob/0.18.1/jmeter-service/chart/README.md#configuration)
+  - `jmeter-service`: [Helm Chart values](https://github.com/keptn/keptn/blob/0.19.1/jmeter-service/chart/README.md#configuration)
 
 The important ones that are used in the above example are:
 


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

Checking the xrefs broken for 1.0.x unearthed some outdated xrefs in 0.19.x docs.  Those are fixed here

https://github.com/keptn/keptn.github.io/issues/1496