### PR TITLE
Remove Hidden Pages from the card overview

### DIFF
--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -21,6 +21,7 @@
     {{ else }}
     {{ range $pages }}
     {{ if eq .Parent $parent }}
+    {{ if not .Params.hide }}
     <div class="entry">
       <h5>
         <a href="{{ .Permalink }}">{{- if .Params.icon -}}<i class="page_icon">
@@ -28,6 +29,7 @@
       </h5>
       <p>{{ .Description }}</p>
     </div>
+    {{ end }}
     {{ end }}
     {{ end }}
     {{ end }}


### PR DESCRIPTION
We are hiding pages within the sidebar with the `hide` flag. This flag was not used in the overview of cards.
We are adding this flag now for rendering cards to remove those hidden pages not just from the menu, but also from the overview.

Signed-off-by: Simon Schrottner <simon.schrottner@dynatrace.com>