### PR TITLE
Remove kubecon announcement

### DIFF
--- a/layouts/partials/announcement.html
+++ b/layouts/partials/announcement.html
@@ -3,10 +3,8 @@
     <div class="row">
       <div class="col-12 d-flex flex-column box-announcements">
         <ul>
-          <li>Join us for Kubecon and <a href="https://community.cncf.io/events/details/cncf-keptn-community-presents-keptn-community-day-kubecon-cloudnativecon-detroit/">Keptn Community Day</a> in Detroit!
-              Community booth in the project pavillion, cool demos, main track talks, and a first ever full-day Keptn event.
-          <li>Check out the <a href="https://github.com/keptn/lifecycle-controller">Lifecycle Controller</a>! Cloud native pre-, post-deployment and application health checks.
-          <li>Keptn 0.19.1 is available! Find <a href="./docs/news/release_announcements/keptn-0191/">details here</a>.
+          <li>Check out the <a href="https://github.com/keptn/lifecycle-controller">Lifecycle Controller</a>! Cloud native pre-, post-deployment and application health checks.</li>
+          <li>Keptn 0.19.1 is available! Find <a href="./docs/news/release_announcements/keptn-0191/">details here</a>.</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
This PR:

- Removes the outdated kubecon announcement from top banner

Signed-off-by: agardnerit <adam@agardner.net>