### PR TITLE
remove tutorials from menu

### DIFF
--- a/layouts/partials/main-menu-mobile.html
+++ b/layouts/partials/main-menu-mobile.html
@@ -11,12 +11,6 @@
     </li>
     {{ end }}
 
-    <li class="menu-item-tutorials">
-      <a href="https://tutorials.keptn.sh">
-        <span>Tutorials</span>
-      </a>
-    </li>
-
     <li class="menu-item-integrations">
       <a href="/docs/integrations/">
         <span>Integrations</span>

--- a/layouts/partials/main-menu.html
+++ b/layouts/partials/main-menu.html
@@ -11,13 +11,6 @@
     </li>
     {{ end }}
 
-
-    <li class="menu-item-tutorials">
-      <a href="https://tutorials.keptn.sh">
-        <span>Tutorials</span>
-      </a>
-    </li>
-
     <li class="menu-item-integrations">
       <a href="/docs/integrations/">
         <span>Integrations</span>


### PR DESCRIPTION
This PR:
- Removes the menu item links to tutorials since they're all out of date and have been removed.

Signed-off-by: agardnerit <adam@agardner.net>