### PR TITLE
[BAD] Merge CLI install and authenticate instructions into single location

### DIFF
--- a/content/docs/1.0.x/install/access/index.md
+++ b/content/docs/1.0.x/install/access/index.md
@@ -24,6 +24,19 @@ Instructions for getting the Keptn endpoint and, optionally,
 storing that endpoint in an environment variable
 are detailed for each option in [Choose access options](../access).
 
+For example, if you are using `LoadBalancer` to expose Keptn,
+your endpoint is `localhost` and the `port` to which you forwarded Keptn
+such as `http://localhost:8080`:
+
+   ```
+   kubectl -n keptn get service api-gateway-nginx
+   ```
+
+   ```
+   NAME                TYPE        CLUSTER-IP    EXTERNAL-IP                  PORT(S)   AGE
+   api-gateway-nginx   ClusterIP   10.117.0.20   <ENDPOINT_OF_API_GATEWAY>    80/TCP    44m
+   ```
+
 
 ## Get API Token and Authenticate Keptn CLI
 
@@ -62,10 +75,18 @@ In the Windows Command Line, do the following:
    set KEPTN_ENDPOINT=http://<ENDPOINT_OF_API_GATEWAY>/api
    ```
 
-1. Get the Keptn API Token encoded in base64 and decode it to plain text:
+1. Get the Keptn API Token encoded in base64:
 
    ```
-   kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 -d > keptn-api-token.txt
+   kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token}
+   ```
+
+1. Save the encoded API token in a text file such as `keptn-api-token-base64.txt`.
+
+1. Decode the file:
+
+   ```
+   certutil -decode keptn-api-token-base64.txt keptn-api-token.txt
    ```
 
 1. Open the newly created file `keptn-api-token.txt`,

--- a/content/docs/1.0.x/install/access/index.md
+++ b/content/docs/1.0.x/install/access/index.md
@@ -24,19 +24,6 @@ Instructions for getting the Keptn endpoint and, optionally,
 storing that endpoint in an environment variable
 are detailed for each option in [Choose access options](../access).
 
-For example, if you are using `LoadBalancer` to expose Keptn,
-your endpoint is `localhost` and the `port` to which you forwarded Keptn
-such as `http://localhost:8080`:
-
-   ```
-   kubectl -n keptn get service api-gateway-nginx
-   ```
-
-   ```
-   NAME                TYPE        CLUSTER-IP    EXTERNAL-IP                  PORT(S)   AGE
-   api-gateway-nginx   ClusterIP   10.117.0.20   <ENDPOINT_OF_API_GATEWAY>    80/TCP    44m
-   ```
-
 
 ## Get API Token and Authenticate Keptn CLI
 
@@ -75,31 +62,17 @@ In the Windows Command Line, do the following:
    set KEPTN_ENDPOINT=http://<ENDPOINT_OF_API_GATEWAY>/api
    ```
 
-1. Get the Keptn API Token encoded in base64:
+1. Get the Keptn API Token encoded in base64 and decode it to plain text:
 
    ```
-   kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token}
-   ```
-
-   ```
-   abcdefghijkladfaea
-   ```
-
-1. Save the encoded API token in a text file such as `keptn-api-token-base64.txt`.
-   The encoded API token is the value from the key `keptn-api-token`;
-   in this example, it is `abcdefghijkladfaea`.
-
-1. Decode the file:
-
-   ```
-   certutil -decode keptn-api-token-base64.txt keptn-api-token.txt
+   kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 -d > keptn-api-token.txt
    ```
 
 1. Open the newly created file `keptn-api-token.txt`,
    copy the value, and paste it into the next command:
 
    ```
-   set KEPTN_API_TOKEN=keptn-api-token
+   set KEPTN_API_TOKEN=<your-token>
    ```
 
 1. To authenticate the CLI against the Keptn cluster,

--- a/content/docs/1.0.x/install/access/index.md
+++ b/content/docs/1.0.x/install/access/index.md
@@ -1,330 +1,136 @@
 ---
-title: Choose access options
-description: Choose the method to use to access Keptn
-weight: 30
+title: Authenticate Keptn CLI and Bridge
+description: Authenticate the Keptn CLI and Bridge to your Keptn cluster
+weight: 60
 ---
- 
-## Access options
 
-Before installing Keptn on your cluster, please also consider how you would like to access Keptn.
-Kubernetes provides the following four options:
+To authenticate and associate the Keptn CLI and Keptn bridge to your Keptn cluster,
+you need the exposed Keptn endpoint and API token.
+The endpoint values and the method of querying them
+are determined by the access options you use.
+See [Choose access options](../access) for details.
 
-* Option 1: Expose Keptn via an **LoadBalancer**
-* Option 2: Expose Keptn via a **NodePort**
-* Option 3: Expose Keptn via a **Ingress**
-* Option 4: Access Keptn via a **Port-forward**
+## Get the Keptn endpoint
 
-An overview of the four options is provided in the graphic below and the respective steps of all options are described below.
+To authenticate the Keptn CLI against the Keptn cluster,
+the exposed Keptn endpoint and API token are required. 
+After [installing Keptn](../helm-install), you already have your Keptn endpoint.
 
-{{< popup_image
-link="./assets/installation_options.png"
-caption="Installation options"
-width="1000px">}}
 
-### Option 1: Expose Keptn via a LoadBalancer
-This option exposes Keptn externally using a cloud provider's load balancer (if available).
+Get the Keptn endpoint from the `api-gateway-nginx`.
+The specifics for getting the Keptn endpoint vary slightly
+depending on the access option you are using for Keptn.
+Instructions for getting the Keptn endpoint and, optionally,
+storing that endpoint in an environment variable
+are detailed for each option in [Choose access options](../access).
 
-1. **Install Keptn:** Use the Helm CLI to install Keptn on your cluster.
-If you want to install the execution plane for continuous delivery, add the flag `continuousDelivery.enabled=true`.
-  ```console
-   helm install keptn keptn/keptn -n keptn --version=$KeptnVersion --create-namespace --set=continuousDelivery.enabled=true,apiGatewayNginx.type=LoadBalancer
-  ```
-
-1. **Get Keptn endpoint:**  Get the EXTERNAL-IP of the `api-gateway-nginx` using the command below. The Keptn API endpoint is: `http://<ENDPOINT_OF_API_GATEWAY>/api`
-  ```console
-  kubectl -n keptn get service api-gateway-nginx
-  ```
-  ```console
-  NAME                TYPE        CLUSTER-IP    EXTERNAL-IP                  PORT(S)   AGE
-  api-gateway-nginx   ClusterIP   10.117.0.20   <ENDPOINT_OF_API_GATEWAY>    80/TCP    44m
-  ```
-
-    *Optional:* Store Keptn API endpoint in an environment variable.
-
-    For Linux and Mac:
-    ```console
-    KEPTN_ENDPOINT=http://<ENDPOINT_OF_API_GATEWAY>/api
-    ```
-
-    For Windows:
-    ```console
-    $Env:KEPTN_ENDPOINT = 'http://<ENDPOINT_OF_API_GATEWAY>/api'
-    ```
-
-:warning: **Warning:** If you do not set up TLS encryption, all your traffic to and from the Keptn endpoint is not encrypted.
-
-### Option 2: Expose Keptn via a NodePort
-This option exposes Keptn on each Kubernetes Node's IP at a static port. Therefore, please make sure that you can access the Kubernetes Nodes in your network.
-
-1. **Install Keptn:** Use the Keptn CLI to install Keptn on your cluster.
-If you want to install the execution plane for continuous delivery, add the flag `continuousDelivery.enabled=true`.
-  ```console
-  helm install keptn keptn/keptn -n keptn --version=$KeptnVersion --create-namespace --set=continuousDelivery.enabled=true,apiGatewayNginx.type=NodePort
-  ```
-
-1. **Get Keptn endpoint:** Get the mapped port of the `api-gateway-nginx` using the command below.
-
-    ```console
-    API_PORT=$(kubectl get svc api-gateway-nginx -n keptn -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
-    ```
-    Next, get the internal or external IP address of any Kubernetes node:
-
-    ```console
-    EXTERNAL_NODE_IP=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses[?(@.type=="ExternalIP")].address }')
-    INTERNAL_NODE_IP=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses[?(@.type=="InternalIP")].address }')
-    ```
-
-    The Keptn API endpoint (either via the internal or external IP; try both if unsure) is: `http://${INTERNAL_NODE_IP}:${API_PORT}/api` or `http://${EXTERNAL_NODE_IP}:${API_PORT}/api`
-
-    *Optional:* Store Keptn API endpoint in an environment variable.
-
-    For Linux and Mac:
-    ```console
-    KEPTN_ENDPOINT=http://${EXTERNAL_NODE_IP}:${API_PORT}/api
-    ```
-
-    For Windows:
-    ```console
-    $Env:KEPTN_ENDPOINT = 'http://${EXTERNAL_NODE_IP}:${API_PORT}/api'
-    ```
-
-:warning: **Warning:** If you do not set up TLS encryption, all your traffic to and from the Keptn endpoint is not encrypted.
-
-### Option 3: Expose Keptn via an Ingress
-
-1. **Install Keptn:** Use the Keptn CLI to install Keptn on your cluster.
-If you want to install the execution plane for continuous delivery, add the flag `continuousDelivery.enabled=true`.
-  ```console
-  helm install keptn keptn/keptn -n keptn --version=$KeptnVersion --create-namespace --set=continuousDelivery.enabled=true
-  ```
-
-1. **Install an Ingress-Controller and create an Ingress:**
-  Please first install your favorite Ingress-Controller and then apply an Ingress object in the `keptn` namespace, 
-  which points to the service `api-gateway-nginx` on port 80. Note that the [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) allows to setup TLS encryption. **Note**: Using Openshift 3.11 requires to use a configuration for this platform.
-
-    Commonly used Ingress controllers are Istio and NGINX:
-
-    <details><summary>**Istio 1.8+** (recommended for use-case continuous delivery)</summary>
-    <p>
-
-    * Istio provides an Ingress Controller. To install Istio, please refer to the [official documentation](https://istio.io/latest/docs/setup/install/).
-
-    * [Determine the ingress IP](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/#determining-the-ingress-ip-and-ports):
-
-      ```console
-    kubectl -n istio-system get svc istio-ingressgateway
-      ```
-
-    * Create an `ingress-manifest.yaml` manifest for an Ingress object in which you set IP-ADDRESS or your hostname and then apply the manifest. (**Note:** In the example below, `nip.io` is used as wildcard DNS for the IP address.)
-
-      ```yaml
-    apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-      annotations:
-        kubernetes.io/ingress.class: istio
-      name: api-keptn-ingress
-      namespace: keptn
-    spec:
-      rules:
-      - host: <IP-ADDRESS>.nip.io
-        http:
-          paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: api-gateway-nginx
-                port:
-                  number: 80
-      ```
-
-      ```console
-    kubectl apply -f ingress-manifest.yaml
-      ```
-
-    </p>
-    </details>
-
-    <details><summary>**Istio 1.8+ on OpenShift 3.11**</summary>
-    <p>
-
-    * Istio provides an Ingress Controller. To install Istio, please refer to the [official documentation](https://istio.io/latest/docs/setup/install/).
-
-    * [Determine the ingress IP](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/#determining-the-ingress-ip-and-ports):
-
-      ```console
-    kubectl -n istio-system get svc istio-ingressgateway
-      ```
-
-    * Create an `ingress-manifest.yaml` manifest for an Ingress object in which you set IP-ADDRESS or your hostname and then apply the manifest. (**Note:** In the example below, `nip.io` is used as wildcard DNS for the IP address.)
-
-      ```yaml
-    apiVersion: networking.k8s.io/v1beta1
-    kind: Ingress
-    metadata:
-      annotations:
-        kubernetes.io/ingress.class: istio
-      name: api-keptn-ingress
-      namespace: keptn
-    spec:
-      rules:
-      - host: <IP-ADDRESS>.nip.io
-        http:
-          paths:
-          - backend:
-              serviceName: api-gateway-nginx
-              servicePort: 80
-      ```
-
-      ```console
-    kubectl apply -f ingress-manifest.yaml
-      ```
-
-    </p>
-    </details>
-
-    <details><summary>**NGINX Ingress**</summary>
-    <p>
-
-    * To install an NGINX Ingress Controller, please refer to the [official documentation](https://kubernetes.github.io/ingress-nginx/).
-
-    * [Determine the ingress IP](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/#determining-the-ingress-ip-and-ports):
-
-      ```console
-    kubectl -n ingress-nginx get svc ingress-nginx
-      ```
-
-    * Create an `ingress-manifest.yaml` manifest for an ingress object in which you set IP-ADDRESS or your hostname and then apply the manifest. (**Note:** In the example below, `nip.io` is used as wildcard DNS for the IP address.)
-
-      ```yaml
-    apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-      annotations:
-        kubernetes.io/ingress.class: nginx
-      name: api-keptn-ingress
-      namespace: keptn
-    spec:
-      rules:
-      - host: <IP-ADDRESS>.nip.io
-        http:
-          paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: api-gateway-nginx
-                port:
-                  number: 80
-      ```
-
-      ```console
-    kubectl apply -f ingress-manifest.yaml
-      ```
-
-    </p>
-    </details>
-
-    <details><summary>**NGINX Ingress on Openshift 3.11**</summary>
-    <p>
-
-    * To install an NGINX Ingress Controller, please refer to the [official documentation](https://kubernetes.github.io/ingress-nginx/).
-
-    * [Determine the ingress IP](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/#determining-the-ingress-ip-and-ports):
-
-      ```console
-    kubectl -n ingress-nginx get svc ingress-nginx
-      ```
-
-    * Create an `ingress-manifest.yaml` manifest for an ingress object in which you set IP-ADDRESS or your hostname and then apply the manifest. (**Note:** In the example below, `nip.io` is used as wildcard DNS for the IP address.)
-
-      ```yaml
-    apiVersion: networking.k8s.io/v1beta1
-    kind: Ingress
-    metadata:
-      annotations:
-        kubernetes.io/ingress.class: nginx
-      name: api-keptn-ingress
-      namespace: keptn
-    spec:
-      rules:
-      - host: <IP-ADDRESS>.nip.io
-        http:
-          paths:
-          - backend:
-              serviceName: api-gateway-nginx
-              servicePort: 80
-      ```
-
-      ```console
-    kubectl apply -f ingress-manifest.yaml
-      ```
-
-    </p>
-    </details>
-
-2. **Get Keptn endpoint:** Get the HOST of the `api-keptn-ingress` using the command below. The Keptn API endpoint is: `http://<HOST>/api`
-
-    ```console
-  kubectl -n keptn get ingress api-keptn-ingress
-    ```
-
-    ```console
-  NAME                HOSTS                  ADDRESS         PORTS   AGE
-  api-keptn-ingress   <HOST>                 x.x.x.x   80      48m
-    ```
-
-    *Optional:* Store Keptn API endpoint in an environment variable.
-
-    For Linux and Mac:
-    ```console
-    KEPTN_ENDPOINT=http://<HOST>/api
-    ```
-
-    For Windows:
-    ```console
-    $Env:KEPTN_ENDPOINT = 'http://<HOST>/api'
-    ```
-
-:warning: **Warning:** If you do not set up TLS encryption, all your traffic to and from the Keptn endpoint is not encrypted.
-
-### Option 4: Access Keptn via a Port-forward
-This option does not expose Keptn to the public but exposes Keptn on a *cluster-internal* IP.
-
-1. **Install Keptn:** Use the Keptn CLI to install Keptn on your cluster.
-If you want to install the execution plane for continuous delivery, add the flag `continuousDelivery.enabled=true`.
-  ```console
-  helm install keptn keptn/keptn -n keptn --version=$KeptnVersion --create-namespace --set=continuousDelivery.enabled=true
-  ```
-
-1. **Setup a Port-Forward:** Configure the port-forward by using the command below.
-  ```console
-  kubectl -n keptn port-forward service/api-gateway-nginx 8080:80
-  ```
-  <details><summary>To listen on any local address</summary>
-  <p>
-  By default, `kubectl port-forward` binds to `127.0.0.1`. If you want to listen on any local address, add `--address 0.0.0.0`:
-    
-    ```console
-    kubectl -n keptn port-forward service/api-gateway-nginx 8080:80 --address 0.0.0.0
-    ```
-  </p>
-  </details>
-
-1. **Get Keptn endpoint:** 
-  The Keptn API endpoint is: `http://localhost:8080/api`
-
-    *Optional:* Store Keptn API endpoint in an environment variable:
-    ```console
-    KEPTN_ENDPOINT=http://localhost:8080/api
-    ```
-
-## Change how to expose Keptn
-
-If you would like to change the way of exposing Keptn,
-you can do this by [re-installing Keptn](../helm-install)
-and selecting the desired configuration.
-When the CLI asks you if you would like to overwrite the installation, confirm this with yes.
-This retains ell your data, including the Git repos and events.
+For example, if you are using `LoadBalancer` to expose Keptn,
+your endpoint is `localhost` and the `port` to which you forwarded Keptn
+such as `http://localhost:8080`:
+
+   ```
+   kubectl -n keptn get service api-gateway-nginx
+   ```
+
+   ```
+   NAME                TYPE        CLUSTER-IP    EXTERNAL-IP                  PORT(S)   AGE
+   api-gateway-nginx   ClusterIP   10.117.0.20   <ENDPOINT_OF_API_GATEWAY>    80/TCP    44m
+   ```
+
+
+## Get API Token and Authenticate Keptn CLI
+
+**On Linux, MacOS, and WSL2**
+
+1. Set the environment variable `KEPTN_API_TOKEN`:
+
+   ```
+   KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn `
+       -ojsonpath={.data.keptn-api-token} | base64 --decode)
+   ```
+
+1. To authenticate the CLI against the Keptn cluster,
+   use the [keptn auth](../../reference/cli/commands/keptn_auth) command
+   with the `KEPTN_ENDPOINT` environment variable;
+   see [Choose access options](../access) for information
+   about how to get the `KEPTN_ENDPOINT` and store it in an environment variable
+   for the access option you are using.
+
+   ```
+   keptn auth --endpoint=$KEPTN_ENDPOINT --api-token=$KEPTN_API_TOKEN
+   ```
+
+   **Note**: If you receive a warning
+   `Using a file-based storage for the key because the password-store seems to be not set up.`,
+   it means that no password store could be found in your environment.
+   In this case, the credentials are stored in `~/.keptn/.password-store` in your home directory.
+
+**Using the Windows Command Line**
+
+In the Windows Command Line, do the following:
+
+1. Set the environment variable `KEPTN_ENDPOINT`:
+
+   ```
+   set KEPTN_ENDPOINT=http://<ENDPOINT_OF_API_GATEWAY>/api
+   ```
+
+1. Get the Keptn API Token encoded in base64:
+
+   ```
+   kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token}
+   ```
+
+   ```
+   abcdefghijkladfaea
+   ```
+
+1. Save the encoded API token in a text file such as `keptn-api-token-base64.txt`.
+   The encoded API token is the value from the key `keptn-api-token`;
+   in this example, it is `abcdefghijkladfaea`.
+
+1. Decode the file:
+
+   ```
+   certutil -decode keptn-api-token-base64.txt keptn-api-token.txt
+   ```
+
+1. Open the newly created file `keptn-api-token.txt`,
+   copy the value, and paste it into the next command:
+
+   ```
+   set KEPTN_API_TOKEN=keptn-api-token
+   ```
+
+1. To authenticate the CLI against the Keptn cluster,
+   use the [keptn auth](../../reference/cli/commands/keptn_auth) command:
+
+   ```
+   keptn.exe auth --endpoint=$Env:KEPTN_ENDPOINT --api-token=$Env:KEPTN_API_TOKEN
+   ```
+## Authenticate Keptn Bridge
+
+After installing and exposing Keptn, you can access the Keptn Bridge by using a browser and navigating to the Keptn endpoint without the `api` path at the end of the URL.
+You can also use the Keptn CLI to retrieve the Bridge URL using:
+
+```
+keptn status
+```
+
+The Keptn Bridge has basic authentication enabled by default and the default user is `keptn` with an automatically generated password.
+
+* To get the username for authentication, execute:
+
+```
+kubectl get secret -n keptn bridge-credentials -o jsonpath="{.data.BASIC_AUTH_USERNAME}" | base64 --decode
+```
+
+* To get the password for authentication, execute:
+
+```
+kubectl get secret -n keptn bridge-credentials -o jsonpath="{.data.BASIC_AUTH_PASSWORD}" | base64 --decode
+```
+
+* If you want to change the user and password for the authentication,
+follow the instructions [here](../../bridge/basic_authentication/#enable-authentication).
 

--- a/content/docs/1.0.x/install/authenticate-cli-bridge/index.md
+++ b/content/docs/1.0.x/install/authenticate-cli-bridge/index.md
@@ -24,19 +24,6 @@ Instructions for getting the Keptn endpoint and, optionally,
 storing that endpoint in an environment variable
 are detailed for each option in [Choose access options](../access).
 
-For example, if you are using `LoadBalancer` to expose Keptn,
-your endpoint is `localhost` and the `port` to which you forwarded Keptn
-such as `http://localhost:8080`:
-
-   ```
-   kubectl -n keptn get service api-gateway-nginx
-   ```
-
-   ```
-   NAME                TYPE        CLUSTER-IP    EXTERNAL-IP                  PORT(S)   AGE
-   api-gateway-nginx   ClusterIP   10.117.0.20   <ENDPOINT_OF_API_GATEWAY>    80/TCP    44m
-   ```
-
 
 ## Get API Token and Authenticate Keptn CLI
 
@@ -81,13 +68,8 @@ In the Windows Command Line, do the following:
    kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token}
    ```
 
-   ```
-   abcdefghijkladfaea
-   ```
 
 1. Save the encoded API token in a text file such as `keptn-api-token-base64.txt`.
-   The encoded API token is the value from the key `keptn-api-token`;
-   in this example, it is `abcdefghijkladfaea`.
 
 1. Decode the file:
 
@@ -99,7 +81,7 @@ In the Windows Command Line, do the following:
    copy the value, and paste it into the next command:
 
    ```
-   set KEPTN_API_TOKEN=keptn-api-token
+   set KEPTN_API_TOKEN=<your-token>
    ```
 
 1. To authenticate the CLI against the Keptn cluster,

--- a/content/docs/1.0.x/install/authenticate-cli-bridge/index.md
+++ b/content/docs/1.0.x/install/authenticate-cli-bridge/index.md
@@ -18,9 +18,15 @@ After [installing Keptn](../helm-install), you already have your Keptn endpoint.
 
 
 Get the Keptn endpoint from the `api-gateway-nginx`.
-If you are using port-forward to expose Keptn,
+The specifics for getting the Keptn endpoint vary slightly
+depending on the access option you are using for Keptn.
+Instructions for getting the Keptn endpoint and, optionally,
+storing that endpoint in an environment variable
+are detailed for each option in [Choose access options](../access).
+
+For example, if you are using `LoadBalancer` to expose Keptn,
 your endpoint is `localhost` and the `port` to which you forwarded Keptn
-such as `http://localhost:8080`.)
+such as `http://localhost:8080`:
 
    ```
    kubectl -n keptn get service api-gateway-nginx
@@ -34,7 +40,7 @@ such as `http://localhost:8080`.)
 
 ## Get API Token and Authenticate Keptn CLI
 
-**On Linux and MacOS**
+**On Linux, MacOS, and WSL2**
 
 1. Set the environment variable `KEPTN_API_TOKEN`:
 
@@ -44,7 +50,11 @@ such as `http://localhost:8080`.)
    ```
 
 1. To authenticate the CLI against the Keptn cluster,
-   use the [keptn auth](../../reference/cli/commands/keptn_auth) command:
+   use the [keptn auth](../../reference/cli/commands/keptn_auth) command
+   with the `KEPTN_ENDPOINT` environment variable;
+   see [Choose access options](../access) for information
+   about how to get the `KEPTN_ENDPOINT` and store it in an environment variable
+   for the access option you are using.
 
    ```
    keptn auth --endpoint=$KEPTN_ENDPOINT --api-token=$KEPTN_API_TOKEN
@@ -54,32 +64,6 @@ such as `http://localhost:8080`.)
    `Using a file-based storage for the key because the password-store seems to be not set up.`,
    it means that no password store could be found in your environment.
    In this case, the credentials are stored in `~/.keptn/.password-store` in your home directory.
-
-**Using Windows PowerShell**
-
-For the Windows PowerShell, a small script is provided
-that installs the `PSYaml` module and sets the environment variables.
-
-1. Set the environment variable `KEPTN_ENDPOINT`:
-
-   ```
-   $Env:KEPTN_ENDPOINT = 'http://<ENDPOINT_OF_API_GATEWAY>/api'
-   ```
-
-1. Copy the following snippet and paste it in the PowerShell.
-   The snippet retrieves the API token and sets the environment variable `KEPTN_API_TOKEN`:
-
-   ```
-   $tokenEncoded = $(kubectl get secret keptn-api-token -n keptn -ojsonpath='{.data.keptn-api-token}')
-   $Env:KEPTN_API_TOKEN = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($tokenEncoded))
-   ```
-
-1. To authenticate the CLI against the Keptn cluster,
-   use the [keptn auth](../../reference/cli/commands/keptn_auth) command:
-
-   ```
-   keptn auth --endpoint=$Env:KEPTN_ENDPOINT --api-token=$Env:KEPTN_API_TOKEN
-   ```
 
 **Using the Windows Command Line**
 
@@ -129,7 +113,7 @@ In the Windows Command Line, do the following:
 After installing and exposing Keptn, you can access the Keptn Bridge by using a browser and navigating to the Keptn endpoint without the `api` path at the end of the URL.
 You can also use the Keptn CLI to retrieve the Bridge URL using:
 
-```console
+```
 keptn status
 ```
 
@@ -137,13 +121,13 @@ The Keptn Bridge has basic authentication enabled by default and the default use
 
 * To get the username for authentication, execute:
 
-```console
+```
 kubectl get secret -n keptn bridge-credentials -o jsonpath="{.data.BASIC_AUTH_USERNAME}" | base64 --decode
 ```
 
 * To get the password for authentication, execute:
 
-```console
+```
 kubectl get secret -n keptn bridge-credentials -o jsonpath="{.data.BASIC_AUTH_PASSWORD}" | base64 --decode
 ```
 

--- a/content/docs/1.0.x/install/authenticate-cli-bridge/index.md
+++ b/content/docs/1.0.x/install/authenticate-cli-bridge/index.md
@@ -7,113 +7,123 @@ weight: 60
 To authenticate and associate the Keptn CLI and Keptn bridge to your Keptn cluster,
 you need the exposed Keptn endpoint and API token.
 The endpoint values and the method of querying them
-is determined by the access options you use.
+are determined by the access options you use.
 See [Choose access options](../access) for details.
 
-## Authenticate Keptn CLI
+## Get the Keptn endpoint
 
-To authenticate the Keptn CLI against the Keptn cluster, the exposed Keptn endpoint and API token are required. 
+To authenticate the Keptn CLI against the Keptn cluster,
+the exposed Keptn endpoint and API token are required. 
 After [installing Keptn](../helm-install), you already have your Keptn endpoint.
 
-<details><summary>Get API Token and Authenticate Keptn CLI on **Linux / MacOS**</summary>
-<p>
 
-* Set the environment variable `KEPTN_API_TOKEN`:
+Get the Keptn endpoint from the `api-gateway-nginx`.
+If you are using port-forward to expose Keptn,
+your endpoint is `localhost` and the `port` to which you forwarded Keptn
+such as `http://localhost:8080`.)
 
-```console
-KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)
-```
+   ```
+   kubectl -n keptn get service api-gateway-nginx
+   ```
 
-* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../reference/cli/commands/keptn_auth) command:
+   ```
+   NAME                TYPE        CLUSTER-IP    EXTERNAL-IP                  PORT(S)   AGE
+   api-gateway-nginx   ClusterIP   10.117.0.20   <ENDPOINT_OF_API_GATEWAY>    80/TCP    44m
+   ```
 
-```console
-keptn auth --endpoint=$KEPTN_ENDPOINT --api-token=$KEPTN_API_TOKEN
-```
 
-**Note**: If you receive a warning `Using a file-based storage for the key because the password-store seems to be not set up.` this is because a password store could not be found in your environment. In this case, the credentials are stored in `~/.keptn/.password-store` in your home directory.
-</p>
-</details>
+## Get API Token and Authenticate Keptn CLI
 
-<details><summary>Get API Token and Authenticate Keptn CLI on **Windows**</summary>
-<p>
+**On Linux and MacOS**
 
-Please expand the corresponding section matching your CLI tool:
+1. Set the environment variable `KEPTN_API_TOKEN`:
 
-<details><summary>PowerShell</summary>
-<p>
+   ```
+   KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn `
+       -ojsonpath={.data.keptn-api-token} | base64 --decode)
+   ```
 
-For the Windows PowerShell, a small script is provided that installs the `PSYaml` module and sets the environment variables.
+1. To authenticate the CLI against the Keptn cluster,
+   use the [keptn auth](../../reference/cli/commands/keptn_auth) command:
 
-* Set the environment variable `KEPTN_ENDPOINT`:
+   ```
+   keptn auth --endpoint=$KEPTN_ENDPOINT --api-token=$KEPTN_API_TOKEN
+   ```
 
-```console
-$Env:KEPTN_ENDPOINT = 'http://<ENDPOINT_OF_API_GATEWAY>/api'
-```
+   **Note**: If you receive a warning
+   `Using a file-based storage for the key because the password-store seems to be not set up.`,
+   it means that no password store could be found in your environment.
+   In this case, the credentials are stored in `~/.keptn/.password-store` in your home directory.
 
-* Copy the following snippet and paste it in the PowerShell. The snippet retrieves the API token and sets the environment variable `KEPTN_API_TOKEN`:
+**Using Windows PowerShell**
 
-```
-$tokenEncoded = $(kubectl get secret keptn-api-token -n keptn -ojsonpath='{.data.keptn-api-token}')
-$Env:KEPTN_API_TOKEN = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($tokenEncoded))
-```
+For the Windows PowerShell, a small script is provided
+that installs the `PSYaml` module and sets the environment variables.
 
-* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../reference/cli/commands/keptn_auth) command:
+1. Set the environment variable `KEPTN_ENDPOINT`:
 
-```
-keptn auth --endpoint=$Env:KEPTN_ENDPOINT --api-token=$Env:KEPTN_API_TOKEN
-```
+   ```
+   $Env:KEPTN_ENDPOINT = 'http://<ENDPOINT_OF_API_GATEWAY>/api'
+   ```
 
-</p>
-</details>
+1. Copy the following snippet and paste it in the PowerShell.
+   The snippet retrieves the API token and sets the environment variable `KEPTN_API_TOKEN`:
 
-<details><summary>Command Line</summary>
-<p>
+   ```
+   $tokenEncoded = $(kubectl get secret keptn-api-token -n keptn -ojsonpath='{.data.keptn-api-token}')
+   $Env:KEPTN_API_TOKEN = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($tokenEncoded))
+   ```
 
-In the Windows Command Line, a couple of steps are necessary.
+1. To authenticate the CLI against the Keptn cluster,
+   use the [keptn auth](../../reference/cli/commands/keptn_auth) command:
 
-* Set the environment variable `KEPTN_ENDPOINT`:
+   ```
+   keptn auth --endpoint=$Env:KEPTN_ENDPOINT --api-token=$Env:KEPTN_API_TOKEN
+   ```
 
-```console
-set KEPTN_ENDPOINT=http://<ENDPOINT_OF_API_GATEWAY>/api
-```
+**Using the Windows Command Line**
 
-* Get the Keptn API Token encoded in base64:
+In the Windows Command Line, do the following:
 
-```console
-kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token}
-```
+1. Set the environment variable `KEPTN_ENDPOINT`:
 
-```console
-abcdefghijkladfaea
-```
+   ```
+   set KEPTN_ENDPOINT=http://<ENDPOINT_OF_API_GATEWAY>/api
+   ```
 
-* Take the encoded API token - it is the value from the key `keptn-api-token` (in this example, it is `abcdefghijkladfaea`) and save it in a text file, e.g., `keptn-api-token-base64.txt`
+1. Get the Keptn API Token encoded in base64:
 
-* Decode the file:
+   ```
+   kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token}
+   ```
 
-```
-certutil -decode keptn-api-token-base64.txt keptn-api-token.txt
-```
+   ```
+   abcdefghijkladfaea
+   ```
 
-* Open the newly created file `keptn-api-token.txt`, copy the value and paste it into the next command:
+1. Save the encoded API token in a text file such as `keptn-api-token-base64.txt`.
+   The encoded API token is the value from the key `keptn-api-token`;
+   in this example, it is `abcdefghijkladfaea`.
 
-```
-set KEPTN_API_TOKEN=keptn-api-token
-```
+1. Decode the file:
 
-* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../reference/cli/commands/keptn_auth) command:
+   ```
+   certutil -decode keptn-api-token-base64.txt keptn-api-token.txt
+   ```
 
-```
-keptn.exe auth --endpoint=$Env:KEPTN_ENDPOINT --api-token=$Env:KEPTN_API_TOKEN
-```
+1. Open the newly created file `keptn-api-token.txt`,
+   copy the value, and paste it into the next command:
 
-</p>
-</details>
-</p>
-</details>
+   ```
+   set KEPTN_API_TOKEN=keptn-api-token
+   ```
 
----
+1. To authenticate the CLI against the Keptn cluster,
+   use the [keptn auth](../../reference/cli/commands/keptn_auth) command:
 
+   ```
+   keptn.exe auth --endpoint=$Env:KEPTN_ENDPOINT --api-token=$Env:KEPTN_API_TOKEN
+   ```
 ## Authenticate Keptn Bridge
 
 After installing and exposing Keptn, you can access the Keptn Bridge by using a browser and navigating to the Keptn endpoint without the `api` path at the end of the URL.

--- a/content/docs/1.0.x/install/cli-install/index.md
+++ b/content/docs/1.0.x/install/cli-install/index.md
@@ -80,8 +80,6 @@ Windows users need `bash`, `curl`, and `awk` installed (e.g., using Git Bash).
    brew uninstall keptn
    ```
 
-## Binaries
-
 ## Manually install Keptn CLI from binaries
 
 Each release of Keptn provides binaries for the Keptn CLI.

--- a/content/docs/1.0.x/install/cli-install/index.md
+++ b/content/docs/1.0.x/install/cli-install/index.md
@@ -26,46 +26,102 @@ You can install the Keptn CLI using:
 
 ## curl
 
-```
-curl -sL https://get.keptn.sh/ | bash
-```
+You can use the `curl` command to install the Keptn CLI on Linux, WSL2, and macOS.
+Windows users need `bash`, `curl`, and `awk` installed (e.g., using Git Bash).
 
-This installs the Keptn CLI for you in the current directory on your cloud shell machine.
-You can use **sudo** to move the file to another location.
-You can run the Keptn CLI from any directory
-but you may need to specify the location of the path,
-using `.keptn` rather than just `keptn` if it is in your current directory.
+1. Download the *latest stable Keptn version*
+   from [GitHub](https://github.com/keptn/keptn/releases),
+   unpack it, and install it into the current directory on your cloud shell machine:
 
-## Homebrew
+   ```
+   curl -sL https://get.keptn.sh/ | bash
+   ```
 
-```
-brew install keptn
-```
+   Use **sudo** to move the file to another location.
+   such as `/usr/local/bin/keptn`.
+   You can run the Keptn CLI from any directory
+   but you may need to specify the location of the path,
+   using `./keptn` rather than just `keptn` if it is in your current directory.
+
+2. Verify that the installation has worked and that the version is correct.
+   On Linux and macOS, run:
+
+    ```
+    keptn version
+    ```
+    On Windows, run:
+
+    ```
+    .\keptn.exe version
+    ```
+## Installation on macOS using brew
+
+1. Run the following command to automatically fetch the latest Keptn CLI via Homebrew:
+
+   ```
+   brew install keptn
+   ```
+
+1. Verify that the installation has worked and that the version is correct by running:
+
+   ```
+   keptn version
+   ```
+
+1. To upgrade Keptn CLI to a new release, run:
+
+   ```
+   brew upgrade keptn
+   ```
+
+1. To uninstall Keptn CLI, run:
+
+   ```
+   brew uninstall keptn
+   ```
 
 ## Binaries
 
-Binaries for the Keptn CLI are provided for Linux, macOS, and Windows.
+## Manually install Keptn CLI from binaries
 
-- Download the latest version for your operating system from: [GitHub](https://github.com/keptn/keptn/releases)
-- Unpack the archive
-- Find the `keptn` binary in the unpacked directory
+Each release of Keptn provides binaries for the Keptn CLI.
+These binaries are available for Linux, macOS, and Windows.
+To install the Keptn CLI from the binaries:
 
-  - *Linux / macOS*: Add executable permissions (``chmod +x keptn``), and move it to the desired destination (e.g. `mv keptn /usr/local/bin/keptn`)
+1. Download the
+   [version matching your operating system](https://github.com/keptn/keptn/releases/).
+1. Unpack the archive.
+1. Find the `keptn` binary in the unpacked directory.
+   * *Linux / macOS*:
+     * Add executable permissions:
+       ```
+       chmod +x keptn
+       ```
+     * Move the `keptn` binary to the desired destination
+       For example,
+       ```
+       mv keptn /usr/local/bin/keptn
+       ```
 
-  - *Windows*: Copy the executable to the desired folder and add the executable to your PATH environment variable.
+   * *Windows*:
+     * Move/copy the executable to the desired folder.
+     * Optionally, add the executable to the `PATH` environment variable.
 
-- Now, verify that the installation has worked and that the version is correct by running:
-    - *Linux / macOS*
+1. Verify that the installation has worked and that the version is correct.
 
-    ```console
-    keptn version
-    ```
+   * On Linux or MacOS, run:
 
-    - *Windows*
+     ```
+     keptn version
+     ```
 
-    ```console
-    .\keptn.exe version
-    ```
+    * On Windows, run:
 
-**Note:** For the rest of the documentation we will stick to the *Linux / macOS* version of the commands.
+      ```
+      .\keptn.exe version
+      ```
+
+After you install both the Keptn CLI and Keptn itself,
+you must authenticate the CLI and the Bridge.
+See [Authenticate Keptn CLI and Bridge](../authenticate-cli-bridge).
 

--- a/content/docs/1.0.x/install/helm-install/index.md
+++ b/content/docs/1.0.x/install/helm-install/index.md
@@ -113,7 +113,7 @@ to port `8080` on the Keptn API Gateway service in the cluster.
 
 **Install Keptn with an Ingress object**
 
-  If you are already using an [Ingress Controller](../access/#option-3-expose-keptn-via-an-ingress)
+  If you are already using an ingress controller
   and want to create an ingress object for Keptn,
   you can leverage the `ingress` section of the Helm chart.
 
@@ -121,7 +121,7 @@ to port `8080` on the Keptn API Gateway service in the cluster.
   When `ingress.enabled` is set to `true` (by default, `enabled` is set to `false`),
   the chart allows you to specify optional parameters
   of `host`, `path`, `pathType`, `tls`, and `annotations`.
-  This supports many different Ingress-Controllers and configurations.
+  This supports many different ingress controllers and configurations.
 
   ```
   helm upgrade keptn keptn --install -n keptn --create-namespace

--- a/content/docs/1.0.x/install/helm-install/index.md
+++ b/content/docs/1.0.x/install/helm-install/index.md
@@ -14,7 +14,7 @@ It is possible to do most of what you need to do on modern releases of Keptn wit
 but the CLI provides additional functionality that is useful
 such as uploading [SLI and SLO](../../concepts/quality_gates/#what-is-a-service-level-indicator-sli) definitions..
 If you install the Keptn CLI,
-you must [authenticate](../authenticate-cli-bridge/#authenticate-keptn-cli)
+you must [authenticate](../authenticate-cli-bridge/)
 it to Keptn after you install Keptn. 
 
 Keptn consists of a **Control Plane** and an **Execution Plane**.

--- a/content/docs/1.0.x/reference/cli/_index.md
+++ b/content/docs/1.0.x/reference/cli/_index.md
@@ -1,197 +1,38 @@
 ---
 title: Keptn CLI
-description: Explains how to download and install the Keptn CLI as well as which commands are available.
+description: Usage information and full syntax of CLI commands.
 weight: 30
 icon: help
 ---
 
-In this section, the functionality and commands of the Keptn CLI are described. The Keptn CLI allows installing, configuring, and uninstalling Keptn. Furthermore, the CLI allows creating projects, services, and sending new artifact events.
+This section provides detailed usage information for the Keptn CLI commands.
+The Keptn CLI includes commands to perform various tasks
+to manage the Keptn installaton and the projects that are run.
+It is packaged separate from the Keptn product itself.
+Current versions of Keptn do not require the Keptn CLI;
+most basic functionality can instead be performed
+using the [Keptn bridge](../../bridge),
+but it is recommended that the CLI be installed for production environments.
 
-## Automatic install of Keptn CLI
-
-**Note**: This will work on Linux (and WSL2), as well as macOS. Windows users need `bash`, `curl`, and `awk` installed (e.g., using Git Bash).
-
-1. Download the *latest stable Keptn version* from [GitHub](https://github.com/keptn/keptn/releases), unpack it and move it to `/usr/local/bin/keptn`.
-```console
-curl -sL https://get.keptn.sh | bash
-```
-
-2. Verify that the installation has worked and that the version is correct by running:
-    ```console
-    keptn version
-    ```
-    or if you are on Windows
-    ```console
-    .\keptn.exe version
-    ```
-
-## Installation on macOS using brew
-
-The following command will automatically fetch the latest Keptn CLI via Homebrew
-
-```sh
-brew install keptn
-```
-
-Verify that the installation has worked and that the version is correct by running:
-```console
-keptn version
-```
-
-### Updating
-
-```sh
-brew upgrade keptn
-```
-
-### Uninstall
-
-```sh
-brew uninstall keptn
-```
-
-## Download and manual install of Keptn CLI
-Every release of Keptn provides binaries for the Keptn CLI. These binaries are available for Linux, macOS, and Windows.
-
-1. Download the [version matching your operating system](https://github.com/keptn/keptn/releases/)
-1. Unpack the download
-1. Find the `keptn` binary in the unpacked directory.
-  - *Linux / macOS*: Add executable permissions (``chmod +x keptn``), and move it to the desired destination (e.g. `mv keptn /usr/local/bin/keptn`)
-
-  - *Windows*: move/copy the executable to the desired folder and, optionally, add the executable to the PATH environment variable for a more convenient experience.
-
-1. Verify that the installation has worked and that the version is correct by running:
-```console
-keptn version
-```
+See the [Install Keptn CLI](../../install/cli-install) for full installation instructions.
+After you install both the Keptn CLI and Keptn itself,
+you must authenticate the CLI and the Bridge.
+See [Authenticate Keptn CLI and Bridge](../../install/authenticate-cli-bridge).
 
 ## Start using Keptn CLI
 
 In the following, the commands provided by the Keptn CLI are described. To list all available commands just execute:
     
-```console
+```
 keptn --help
 ```
 
-All of these commands also support the help flag (`--help`), which describes details of the respective command (e.g., usage of the command or description of flags).
+All of the Keptn CLI commands also support the help flag (`--help`),
+which describes details of the respective command,
+including usage tips for the command and description of flags and arguments.
 
-## Authenticate Keptn CLI
-
-To authenticate the Keptn CLI against the Keptn cluster, the exposed Keptn endpoint and API token are required. 
-
-* Get the Keptn endpoint from the `api-gateway-nginx`. (If you are using port-forward to expose Keptn, your endpoint is `localhost` and the `port` you forwarded Keptn to, e.g.: `http://localhost:8080`) 
-
-  ```console
-kubectl -n keptn get service api-gateway-nginx
-  ```
-
-  ```console
-NAME                TYPE        CLUSTER-IP    EXTERNAL-IP                  PORT(S)   AGE
-api-gateway-nginx   ClusterIP   10.117.0.20   <ENDPOINT_OF_API_GATEWAY>    80/TCP    44m
-  ```
-
-<details><summary>Retrieve API Token and Authenticate Keptn CLI on **Linux / macOS**</summary>
-<p>
-
-* Set the environment variable `KEPTN_ENDPOINT`:
-
-```console
-KEPTN_ENDPOINT=<ENDPOINT_OF_API_GATEWAY>
-```
-
-* Set the environment variable `KEPTN_API_TOKEN`:
-
-```console
-KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)
-```
-
-* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../reference/cli/commands/keptn_auth) command:
-
-```console
-keptn auth --endpoint=$KEPTN_ENDPOINT --api-token=$KEPTN_API_TOKEN
-```
-
-**Note**: If you receive a warning `Using a file-based storage for the key because the password-store seems to be not set up.` this is because a password store could not be found in your environment. In this case, the credentials are stored in `~/.keptn/.password-store` in your home directory.
-</p>
-</details>
-
-<details><summary>Retrieve API Token and Authenticate Keptn CLI on **Windows**</summary>
-<p>
-
-Please expand the corresponding section matching your CLI tool:
-
-<details><summary>PowerShell</summary>
-<p>
-
-For the Windows PowerShell, a small script is provided that installs the `PSYaml` module and sets the environment variables.
-
-* Set the environment variable `KEPTN_ENDPOINT`:
-
-```console
-$Env:KEPTN_ENDPOINT = '<ENDPOINT_OF_API_GATEWAY>'
-```
-
-* Copy the following snippet and paste it in the PowerShell. The snippet retrieves the API token and sets the environment variable `KEPTN_API_TOKEN`:
-
-```
-$tokenEncoded = $(kubectl get secret keptn-api-token -n keptn -ojsonpath='{.data.keptn-api-token}')
-$Env:KEPTN_API_TOKEN = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($tokenEncoded))
-```
-
-* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../reference/cli/commands/keptn_auth) command:
-
-```
-keptn auth --endpoint=$Env:KEPTN_ENDPOINT --api-token=$Env:KEPTN_API_TOKEN
-```
-
-</p>
-</details>
-
-<details><summary>Command Line</summary>
-<p>
-
-In the Windows Command Line, a couple of steps are necessary.
-
-* Set the environment variable `KEPTN_ENDPOINT`:
-
-```console
-set KEPTN_ENDPOINT=<ENDPOINT_OF_API_GATEWAY>
-```
-
-* Get the Keptn API Token encoded in base64:
-
-```console
-kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token}
-```
-
-```console
-abcdefghijkladfaea
-```
-
-* Take the encoded API token - it is the value from the key `keptn-api-token` (in this example, it is `abcdefghijkladfaea`) and save it in a text file, e.g., `keptn-api-token-base64.txt`
-
-* Decode the file:
-
-```
-certutil -decode keptn-api-token-base64.txt keptn-api-token.txt
-```
-
-* Open the newly created file `keptn-api-token.txt`, copy the value and paste it into the next command:
-
-```
-set KEPTN_API_TOKEN=keptn-api-token
-```
-
-* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../reference/cli/commands/keptn_auth) command:
-
-```
-keptn.exe auth --endpoint=%KEPTN_ENDPOINT% --api-token=%KEPTN_API_TOKEN%
-```
-
-</p>
-</details>
-</p>
-</details>
+The rest of this introduction provides some usage notes
+to make the Keptn CLI more convenient.
 
 ## Use Keptn CLI with multiple contexts
 


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

The docs had duplicate instructions for installing and authenticating the CLI -- one set under "Installation", the other on the introductory page for the CLI reference pages.  This PR:

* Merges the instructions into files under "Installation"
* Replaces the instructions in the CLI intro with links to the instructions in "Installation"