### PR TITLE
remove quickstart, roadmap, tutorial links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -21,7 +21,7 @@ ignoreFiles = [
 
 [params]
     google_analytics_id="UA-133584243-1"
-    version="0.19.x"
+    version="1.0.x"
 
 [params.carouselHomepage]
     enable = true

--- a/content/docs/1.0.x/_index.md
+++ b/content/docs/1.0.x/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Release 1.0.x -- LTS
+title: Release 1.0.x LTS
 linktitle: Release 1.0.x
 weight: 788
 sidebar_multicard: true

--- a/content/docs/quickstart/_index.md
+++ b/content/docs/quickstart/_index.md
@@ -3,6 +3,7 @@ title: Quick Start
 description: Learn how to get Keptn running and explore a few basic features.
 icon: concepts
 layout: quickstart
+hide: true
 weight: 15
 hidechildren: true # this flag hides all sub-pages in the sidebar-multicard.html
 ---

--- a/content/docs/roadmap/_index.md
+++ b/content/docs/roadmap/_index.md
@@ -4,6 +4,7 @@ description: Find the Keptn Roadmap here
 icon: concepts
 layout: quickstart
 weight: 90
+hide: true
 hidechildren: true # this flag hides all sub pages in the sidebar-multicard.html
 ---
 


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

Replaces https://github.com/keptn/keptn.github.io/pull/1543 which has some bizarre xref test failures.

Supplements https://github.com/keptn/keptn.github.io/pull/1547 , which deprecates some older releases.