### PR TITLE
Fixed typo in the Contributing Guide

### DIFF
--- a/content/community/contributing/index.md
+++ b/content/community/contributing/index.md
@@ -19,8 +19,8 @@ regardless of your background and experience!
 
 ## Keptn development
 
-If you are interested 
-Most of the Keptn codebase is implemented in Golang and JavaScript/Angular.
+If you are interested, 
+most of the Keptn codebase is implemented in Golang and JavaScript/Angular.
 We also heavily use Kubernetes, Helm, Docker and
 other container technologies like CloudEvents and OpenTelemetry.
 


### PR DESCRIPTION
On [https://keptn.sh/community/contributing/](https://keptn.sh/community/contributing/) there's a typo at the line

"If you are **interested Most of the Keptn codebase** is implemented in Golang and JavaScript/Angular"

The above typo has been fixed to

"If you are **interested, most of the Keptn codebase** is implemented in Golang and JavaScript/Angular"

Signed-off-by: Chaitanya Bisht [chaitanya.bisht10@gmail.com](mailto:chaitanya.bisht10@gmail.com)
