### PR TITLE
Add aliases for moved pages

### DIFF
--- a/content/docs/1.0.x/bridge/version_check/index.md
+++ b/content/docs/1.0.x/bridge/version_check/index.md
@@ -2,6 +2,9 @@
 title: Daily Version Check
 description: Enable/Disable daily version check feature
 weight: 40
+aliases:
+  - /docs/1.0.x/reference/version_check/
+  - /docs/1.0.x/bridge/load_information/
 ---
 
 The feature of a daily version check informs a Keptn user in the Keptn Bridge about:

--- a/content/docs/1.0.x/define/delivery_assistant/index.md
+++ b/content/docs/1.0.x/define/delivery_assistant/index.md
@@ -2,6 +2,9 @@
 title: Delivery Assistant
 description: Approval to control the delivery process
 weight: 55
+aliases:
+  - /docs/1.0.x/continuous_delivery/delivery_assistant/
+  - /docs/1.0.x/reference/bridge/delivery_assistent/
 ---
 
 If you would like to extend the [delivery sequence](../delivery_sequence)

--- a/content/docs/1.0.x/define/delivery_sequence/index.md
+++ b/content/docs/1.0.x/define/delivery_sequence/index.md
@@ -2,6 +2,8 @@
 title: Delivery sequence
 description: Customize your delivery and staging process.
 weight: 40
+aliases:
+- /docs/1.0.x/continuous_delivery/multi_stage
 ---
 
 ## Declare a multi-stage delivery sequence in shipyard

--- a/content/docs/1.0.x/define/deployment_helm/index.md
+++ b/content/docs/1.0.x/define/deployment_helm/index.md
@@ -2,6 +2,8 @@
 title: Deployment with Helm
 description: Details about Keptn using Helm for deployment.
 weight: 140
+aliases:
+- /docs/1.0.x/continuous_delivery/deployment_helm/
 ---
 
 Keptn uses [Helm v3](https://helm.sh/) to deploy services to a Kubernetes cluster. This is currently implemented in the [helm-service](https://github.com/keptn/keptn/tree/1.0.0/helm-service).

--- a/content/docs/1.0.x/define/quality-gates/index.md
+++ b/content/docs/1.0.x/define/quality-gates/index.md
@@ -2,6 +2,10 @@
 title: Quality Gates evaluations
 description: Implement Quality Gate evaluations in your project
 weight: 50
+aliases:
+- /docs/1.0.x/quality_gates/
+- /docs/1.0.x/quality_gates/get_started/
+- /docs/1.0.x/quality_gates/integration/
 ---
 
 A quality gate allows you to validate a deployment or release


### PR DESCRIPTION
within 0.19 we added aliases for moved pages - we have forgotten to also move them to the new version. This is fixing the build for the future.

Signed-off-by: Simon Schrottner <simon.schrottner@dynatrace.com>