### PR TITLE
Add proper aliases for missing canonical urls

### DIFF
--- a/content/docs/0.14.x/integrations/custom_integration/index.md
+++ b/content/docs/0.14.x/integrations/custom_integration/index.md
@@ -388,6 +388,6 @@ If the error log event should not be associated to an execution of a specific ta
 
 ## See also
 
-* [Distributor](../../reference/miscellaneous/distributor)
-* [distributor.yaml](../../reference/files/distributor.yaml)
+* [Distributor](../../reference/miscellaneous/distributor/)
+* [distributor.yaml](../../reference/files/distributor.yaml/)
 

--- a/content/docs/0.14.x/reference/miscellaneous/distributor/index.md
+++ b/content/docs/0.14.x/reference/miscellaneous/distributor/index.md
@@ -196,6 +196,6 @@ for details.
 
 ## See also
 
-* [distributor.yaml](../../files/distributor.yaml)
-* [Write a Keptn-service](../../../integrations/custom_integration)
+* [distributor.yaml](../../files/distributor.yaml/)
+* [Write a Keptn-service](../../../integrations/custom_integration/)
 

--- a/content/docs/1.0.x/bridge/_index.md
+++ b/content/docs/1.0.x/bridge/_index.md
@@ -2,6 +2,8 @@
 title: Keptn Bridge (Web UI)
 description: Keptn dashboard used to view and manage projects and services managed by Keptn.
 weight: 410
+aliases:
+- /docs/1.0.x/reference/bridge/
 ---
 
 The Keptn Bridge is the Keptn user interface.

--- a/content/docs/1.0.x/bridge/basic_authentication/index.md
+++ b/content/docs/1.0.x/bridge/basic_authentication/index.md
@@ -3,6 +3,8 @@ title: Basic Authentication
 description: Enable/Disable basic authentication
 weight: 10
 keywords: [1.0.x-bridge]
+aliases:
+- /docs/1.0.x/reference/bridge/basic_authentication/
 ---
 
 The Keptn Bridge has a basic authentication feature, which can be controlled by setting the following two environment variables in the deployment of the bridge:

--- a/content/docs/1.0.x/bridge/deep_linking/index.md
+++ b/content/docs/1.0.x/bridge/deep_linking/index.md
@@ -3,6 +3,8 @@ title: Deep Linking
 description: Deep links into Bridge for better integration into DevOps tools
 weight: 30
 keywords: [1.0.x-bridge]
+aliases:
+- /docs/1.0.x/reference/bridge/deep_linking/
 ---
 
 A list of deep links is provided to integrate the Keptn Bridge into DevOps tools.

--- a/content/docs/1.0.x/bridge/manage_projects/index.md
+++ b/content/docs/1.0.x/bridge/manage_projects/index.md
@@ -3,6 +3,9 @@ title: Manage Projects
 description: Create, update and delete projects from the Bridge
 weight: 40
 keywords: [1.0.x-bridge]
+
+aliases:
+- /docs/1.0.x/reference/bridge/manage_projects/
 ---
 
 The Bridge provides features to make managing projects more convenient. It is possible to create and update projects directly from the UI.

--- a/content/docs/1.0.x/bridge/manage_sequences/index.md
+++ b/content/docs/1.0.x/bridge/manage_sequences/index.md
@@ -3,6 +3,8 @@ title: Manage Sequences
 description: Manage sequences from the Bridge
 weight: 40
 keywords: [1.0.x-bridge]
+aliases:
+- /docs/1.0.x/reference/bridge/manage_sequences/
 ---
 
 ## Trigger new sequences

--- a/content/docs/1.0.x/bridge/manage_services/index.md
+++ b/content/docs/1.0.x/bridge/manage_services/index.md
@@ -3,6 +3,8 @@ title: Manage Services
 description: Create, update and delete services from the Bridge
 weight: 40
 keywords: [1.0.x-bridge]
+aliases:
+- /docs/1.0.x/reference/bridge/manage_services/
 ---
 
 The Bridge provides features to make managing services more convenient. It is possible to create and delete services directly from the UI.

--- a/content/docs/1.0.x/bridge/oauth/index.md
+++ b/content/docs/1.0.x/bridge/oauth/index.md
@@ -5,6 +5,7 @@ weight: 20
 keywords: [0.11.x-bridge]
 aliases:
   - /docs/0.11.x/operate/user_management/openid_authentication/
+  - /docs/1.0.x/reference/bridge/oauth/
 ---
 
 ## Enable/Disable Authentication

--- a/content/docs/1.0.x/bridge/version_check/index.md
+++ b/content/docs/1.0.x/bridge/version_check/index.md
@@ -5,6 +5,7 @@ weight: 40
 aliases:
   - /docs/1.0.x/reference/version_check/
   - /docs/1.0.x/bridge/load_information/
+  - /docs/1.0.x/reference/load_information/
 ---
 
 The feature of a daily version check informs a Keptn user in the Keptn Bridge about:

--- a/content/docs/1.0.x/define/quality-gates/index.md
+++ b/content/docs/1.0.x/define/quality-gates/index.md
@@ -6,6 +6,8 @@ aliases:
 - /docs/1.0.x/quality_gates/
 - /docs/1.0.x/quality_gates/get_started/
 - /docs/1.0.x/quality_gates/integration/
+- /docs/1.0.x/quality_gates/sli/
+- /docs/1.0.x/quality_gates/slo/
 ---
 
 A quality gate allows you to validate a deployment or release

--- a/content/docs/1.0.x/install/monitoring/index.md
+++ b/content/docs/1.0.x/install/monitoring/index.md
@@ -3,6 +3,8 @@ title: Monitoring
 description: Install service to attach observability platform as data source for quality gates
 weight: 80
 icon: setup
+aliases:
+    - /docs/1.0.x/monitoring/dynatrace/sli_provider/
 ---
 
 If your project uses [quality gates](../../concepts/quality_gates),

--- a/content/docs/1.0.x/install/upgrade/index.md
+++ b/content/docs/1.0.x/install/upgrade/index.md
@@ -2,6 +2,8 @@
 title: Upgrade Keptn
 description: Upgrade your Keptn
 weight: 500
+aliases:
+- /docs/1.0.x/integrations/migrate_from_070_to_080/
 ---
 
 Keptn only supports upgrading from one release to the next;

--- a/content/docs/1.0.x/integrations/webhooks/_index.md
+++ b/content/docs/1.0.x/integrations/webhooks/_index.md
@@ -3,6 +3,8 @@ title: Webhook Integration
 description: Learn how to integrate external tooling using Webhooks
 weight: 2
 keywords: [1.0.0-integration]
+aliases:
+  - /docs/1.0.x/integrations/webhooks/slack/
 ---
 
 Keptn has a built-in capability, via the [Keptn webhook service](https://github.com/keptn/keptn/tree/master/webhook-service), to call external HTTP endpoints as part of sequence task orchestration. 

--- a/content/docs/1.0.x/reference/files/distributor/index.md
+++ b/content/docs/1.0.x/reference/files/distributor/index.md
@@ -2,6 +2,8 @@
 title: distributor
 description: Define a distributor
 weight: 125
+aliases:
+- /docs/1.0.x/reference/files/distributor.yaml/
 ---
 
 You can create your own distributor by writing a dedicated distributor deployment yaml:


### PR DESCRIPTION
Our htmltest only checks newer versions, but there have been missing canonical urls to our newest version. We are adding those now, so our URLs are better configured.

Signed-off-by: Simon Schrottner <simon.schrottner@dynatrace.com>

![image](https://user-images.githubusercontent.com/9987394/209283696-e4cd93e0-8d5c-42a3-a81e-41f5195c26e5.png)
should tackle a lot of those issues