### PR TITLE
docs: fix installation docs for helm/jmeter service for LTS release

### DIFF
--- a/content/docs/1.0.x/install/helm-install/index.md
+++ b/content/docs/1.0.x/install/helm-install/index.md
@@ -186,10 +186,10 @@ install a microservice.
 For example, the following two commands install the Jmeter and Helm-service microservices:
 
 ```
-helm install jmeter-service https://github.com/keptn/keptn/releases/download/1.0.0/jmeter-service-1.0.0.tgz  \
+helm install jmeter-service https://github.com/keptn-contrib/jmeter-service/releases/download/0.18.1/jmeter-service-0.18.1.tgz  \
   -n keptn --create-namespace --wait
 
-helm install helm-service https://github.com/keptn/keptn/releases/download/1.0.0/helm-service-1.0.0.tgz \
+helm install helm-service https://github.com/keptn-contrib/helm-service/releases/download/0.18.1/helm-service-0.18.1.tgz \
   -n keptn --create-namespace --wait
 ```
 
@@ -242,8 +242,8 @@ The following artifacts must be available locally:
 Download the Helm charts from the [Keptn 1.0.x release](https://github.com/keptn/keptn/releases/tag/1.0.0):
 
 * Keptn Control Plane: https://github.com/keptn/keptn/releases/download/1.0.0/keptn-1.0.0.tgz
-* helm-service (if needed): https://github.com/keptn/keptn/releases/download/1.0.0/helm-service-1.0.0.tgz
-* jmeter-service (if needed): https://github.com/keptn/keptn/releases/download/1.0.0/jmeter-service-1.0.0.tgz
+* helm-service (if needed): https://github.com/keptn-contrib/helm-service/releases/download/0.18.1/helm-service-0.18.1.tgz
+* jmeter-service (if needed): https://github.com/keptn-contrib/jmeter-service/releases/download/0.18.1/jmeter-service-0.18.1.tgz
 
 Move the Helm Charts to a directory on your local machine, e.g., `offline-keptn`.
 
@@ -253,8 +253,8 @@ For convenience, the following script creates this directory and downloads the r
 mkdir offline-keptn
 cd offline-keptn
 curl -L https://github.com/keptn/keptn/releases/download/1.0.0/keptn-1.0.0.tgz -o keptn-1.0.0.tgz
-curl -L https://github.com/keptn/keptn/releases/download/1.0.0/helm-service-1.0.0.tgz -o helm-service-1.0.0.tgz
-curl -L https://github.com/keptn/keptn/releases/download/1.0.0/jmeter-service-1.0.0.tgz -o jmeter-service-1.0.0.tgz
+curl -L https://github.com/keptn-contrib/helm-service/releases/download/0.18.1/helm-service-0.18.1.tgz -o helm-service-0.18.1.tgz
+curl -L https://github.com/keptn-contrib/jmeter-service/releases/download/0.18.1/jmeter-service-0.18.1.tgz -o jmeter-service-0.18.1.tgz
 cd ..
 ```
 
@@ -290,7 +290,7 @@ cd offline-keptn
 curl -L https://raw.githubusercontent.com/keptn/keptn/1.0.0/installer/airgapped/install_keptn.sh -o install_keptn.sh
 chmod +x install_keptn.sh
 ./install_keptn.sh "your-registry.localhost:5000/" keptn-1.0.0.tgz \
-   helm-service-1.0.0.tgz jmeter-service-1.0.0.tgz
+   helm-service-0.18.1.tgz jmeter-service-0.18.1.tgz
 cd ..
 ```
 

--- a/content/docs/1.0.x/install/helm-install/index.md
+++ b/content/docs/1.0.x/install/helm-install/index.md
@@ -239,7 +239,7 @@ The following artifacts must be available locally:
 
 **Download Keptn Helm Charts**
 
-Download the Helm charts from the [Keptn 1.0.x release](https://github.com/keptn/keptn/releases/tag/1.0.0):
+Download the Helm charts from the GitHub release pages:
 
 * Keptn Control Plane: https://github.com/keptn/keptn/releases/download/1.0.0/keptn-1.0.0.tgz
 * helm-service (if needed): https://github.com/keptn-contrib/helm-service/releases/download/0.18.1/helm-service-0.18.1.tgz

--- a/content/docs/1.0.x/install/upgrade/index.md
+++ b/content/docs/1.0.x/install/upgrade/index.md
@@ -91,7 +91,7 @@ and use that merged file to upgrade the service:
      the command is:
 
      ```
-     helm pull https://charts.keptn.sh/packages/helm-service-1.0.0.tgz`
+     helm pull https://charts.keptn.sh/packages/helm-service-0.18.1.tgz`
      ```
 
 1. Unpack the downloaded file.

--- a/content/docs/1.0.x/install/upgrade/index.md
+++ b/content/docs/1.0.x/install/upgrade/index.md
@@ -87,7 +87,7 @@ and use that merged file to upgrade the service:
    helm pull https://charts.keptn.sh/packages/<exec-plane-service>-<release>.tgz`
    ```
 
-     For example, to download the Helm chart for `helm-service`, Release 1.0.0,
+     For example, to download the Helm chart for `helm-service`, Release 0.18.1,
      the command is:
 
      ```
@@ -99,10 +99,10 @@ and use that merged file to upgrade the service:
    and your previously downloaded `old-values.yaml` together.
 1. Use the merged `values` file and the `helm` command to do the upgrade
    to upgrade to the new version of your execution plane service.
-   For the `helm-service` example, the command to upgrade to version 1.0.0 is:
+   For the `helm-service` example, the command to upgrade to version 0.18.1 is:
 
    ```
-   helm upgrade <your-exec-plane-service> -n exec-plane --version 1.0.0 \
+   helm upgrade <your-exec-plane-service> -n exec-plane --version 0.18.1 \
      --values <your-adjusted-values-file>
    ```
 


### PR DESCRIPTION
### This PR
- fixes the versions for helm-service and jmeter-service. They were set to 1.0.0 but the service version that is compatible with Keptn 1.0.0 is 0.18.1