### PR TITLE
Move CLI install/authenticate info from CLI ref to install section

### DIFF
--- a/content/docs/1.0.x/install/authenticate-cli-bridge/index.md
+++ b/content/docs/1.0.x/install/authenticate-cli-bridge/index.md
@@ -106,7 +106,7 @@ kubectl get secret -n keptn bridge-credentials -o jsonpath="{.data.BASIC_AUTH_PA
 ```
 
 * If you want to change the user and password for the authentication,
-follow the instructions [here](../../bridge/basic_authentication/#enable-authentication/).
+follow the instructions [here](../../bridge/basic_authentication/#enable-authentication).
 
 See [OpenID Authorization](../../bridge/oauth/)
 for information about using OAUTH authorization for the Keptn Bridge.

--- a/content/docs/1.0.x/install/authenticate-cli-bridge/index.md
+++ b/content/docs/1.0.x/install/authenticate-cli-bridge/index.md
@@ -4,139 +4,110 @@ description: Authenticate the Keptn CLI and Bridge to your Keptn cluster
 weight: 60
 ---
 
-To authenticate and associate the Keptn CLI and Keptn bridge to your Keptn cluster,
-you need the exposed Keptn endpoint and API token.
-The endpoint values and the method of querying them
-is determined by the access options you use.
-See [Choose access options](../access/) for details.
+After you [instal Keptn](../helm-install),
+you must authenticate the Keptn CLI and Bridge against the Keptn cluster.
+To do this, you need to:
 
-## Authenticate Keptn CLI
+* Get the exposed Keptn endpoint
+* Get the API token
+* Run `keptn auth`, supplying the Keptn endpoint and API token
 
-To authenticate the Keptn CLI against the Keptn cluster, the exposed Keptn endpoint and API token are required. 
-After [installing Keptn](../helm-install/), you already have your Keptn endpoint.
+The Keptn endpoint and the API token  are created during the Keptn installation.
 
-<details><summary>Get API Token and Authenticate Keptn CLI on **Linux / MacOS**</summary>
-<p>
+## Authenticate CLI on Linux and MacOS
 
-* Set the environment variable `KEPTN_API_TOKEN`:
+Do the following from the shell:
 
-```console
-KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)
-```
+1.  Get the Keptn endpoint from the `api-gateway-nginx`.
+    Follow the instructions in [Choose access options](../access)
+    to get the Keptn endpoint for the access option you are using
+    and, optionally, storing that endpoint in an environment variable.
 
-* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../reference/cli/commands/keptn_auth/) command:
+1. Set the environment variable `KEPTN_API_TOKEN`:
 
-```console
-keptn auth --endpoint=$KEPTN_ENDPOINT --api-token=$KEPTN_API_TOKEN
-```
+   ```
+   KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn `
+       -ojsonpath={.data.keptn-api-token} | base64 --decode)
+   ```
 
-**Note**: If you receive a warning `Using a file-based storage for the key because the password-store seems to be not set up.` this is because a password store could not be found in your environment. In this case, the credentials are stored in `~/.keptn/.password-store` in your home directory.
-</p>
-</details>
+1. To authenticate the CLI against the Keptn cluster,
+   use the [keptn auth](../../reference/cli/commands/keptn_auth) command:
 
-<details><summary>Get API Token and Authenticate Keptn CLI on **Windows**</summary>
-<p>
+   ```
+   keptn auth --endpoint=$KEPTN_ENDPOINT --api-token=$KEPTN_API_TOKEN
+   ```
 
-Please expand the corresponding section matching your CLI tool:
+   **Note**: If you receive a warning
+   `Using a file-based storage for the key because the password-store seems to be not set up.`,
+   it means that no password store could be found in your environment.
+   In this case, the credentials are stored in `~/.keptn/.password-store` in your home directory.
 
-<details><summary>PowerShell</summary>
-<p>
+## Authenticate CLI on Windows
 
-For the Windows PowerShell, a small script is provided that installs the `PSYaml` module and sets the environment variables.
+Do the folllowing in the Windows Command Line:
 
-* Set the environment variable `KEPTN_ENDPOINT`:
+1. Set the environment variable `KEPTN_ENDPOINT`:
 
-```console
-$Env:KEPTN_ENDPOINT = 'http://<ENDPOINT_OF_API_GATEWAY>/api'
-```
+   ```
+   set KEPTN_ENDPOINT=http://<ENDPOINT_OF_API_GATEWAY>/api
+   ```
 
-* Copy the following snippet and paste it in the PowerShell. The snippet retrieves the API token and sets the environment variable `KEPTN_API_TOKEN`:
+1. Get the Keptn API Token encoded in base64:
 
-```
-$tokenEncoded = $(kubectl get secret keptn-api-token -n keptn -ojsonpath='{.data.keptn-api-token}')
-$Env:KEPTN_API_TOKEN = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($tokenEncoded))
-```
+   ```
+   kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token}
+   ```
 
-* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../reference/cli/commands/keptn_auth/) command:
 
-```
-keptn auth --endpoint=$Env:KEPTN_ENDPOINT --api-token=$Env:KEPTN_API_TOKEN
-```
+1. Save the encoded API token in a text file such as `keptn-api-token-base64.txt`.
 
-</p>
-</details>
+1. Decode the file:
 
-<details><summary>Command Line</summary>
-<p>
+   ```
+   certutil -decode keptn-api-token-base64.txt keptn-api-token.txt
+   ```
 
-In the Windows Command Line, a couple of steps are necessary.
+1. Open the newly created file `keptn-api-token.txt`,
+   copy the value, and paste it into the next command:
 
-* Set the environment variable `KEPTN_ENDPOINT`:
+   ```
+   set KEPTN_API_TOKEN=<your-token>
+   ```
 
-```console
-set KEPTN_ENDPOINT=http://<ENDPOINT_OF_API_GATEWAY>/api
-```
+1. To authenticate the CLI against the Keptn cluster,
+   use the [keptn auth](../../reference/cli/commands/keptn_auth) command:
 
-* Get the Keptn API Token encoded in base64:
-
-```console
-kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token}
-```
-
-```console
-abcdefghijkladfaea
-```
-
-* Take the encoded API token - it is the value from the key `keptn-api-token` (in this example, it is `abcdefghijkladfaea`) and save it in a text file, e.g., `keptn-api-token-base64.txt`
-
-* Decode the file:
-
-```
-certutil -decode keptn-api-token-base64.txt keptn-api-token.txt
-```
-
-* Open the newly created file `keptn-api-token.txt`, copy the value and paste it into the next command:
-
-```
-set KEPTN_API_TOKEN=keptn-api-token
-```
-
-* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../reference/cli/commands/keptn_auth/) command:
-
-```
-keptn.exe auth --endpoint=$Env:KEPTN_ENDPOINT --api-token=$Env:KEPTN_API_TOKEN
-```
-
-</p>
-</details>
-</p>
-</details>
-
----
+   ```
+   keptn.exe auth --endpoint=$Env:KEPTN_ENDPOINT --api-token=$Env:KEPTN_API_TOKEN
+   ```
 
 ## Authenticate Keptn Bridge
 
 After installing and exposing Keptn, you can access the Keptn Bridge by using a browser and navigating to the Keptn endpoint without the `api` path at the end of the URL.
 You can also use the Keptn CLI to retrieve the Bridge URL using:
 
-```console
+```
 keptn status
 ```
 
-The Keptn Bridge has basic authentication enabled by default and the default user is `keptn` with an automatically generated password.
+The Keptn Bridge has [basic authentication](../../bridge/basic_authentication)
+enabled by default and the default user is `keptn` with an automatically generated password.
 
 * To get the username for authentication, execute:
 
-```console
+```
 kubectl get secret -n keptn bridge-credentials -o jsonpath="{.data.BASIC_AUTH_USERNAME}" | base64 --decode
 ```
 
 * To get the password for authentication, execute:
 
-```console
+```
 kubectl get secret -n keptn bridge-credentials -o jsonpath="{.data.BASIC_AUTH_PASSWORD}" | base64 --decode
 ```
 
 * If you want to change the user and password for the authentication,
 follow the instructions [here](../../bridge/basic_authentication/#enable-authentication).
+
+See [OpenID Authorization](../../bridge/oauth)
+for information about using OAUTH authorization for the Keptn Bridge.
 

--- a/content/docs/1.0.x/install/authenticate-cli-bridge/index.md
+++ b/content/docs/1.0.x/install/authenticate-cli-bridge/index.md
@@ -4,7 +4,7 @@ description: Authenticate the Keptn CLI and Bridge to your Keptn cluster
 weight: 60
 ---
 
-After you [instal Keptn](../helm-install),
+After you [instal Keptn](../helm-install/),
 you must authenticate the Keptn CLI and Bridge against the Keptn cluster.
 To do this, you need to:
 
@@ -19,7 +19,7 @@ The Keptn endpoint and the API token  are created during the Keptn installation.
 Do the following from the shell:
 
 1.  Get the Keptn endpoint from the `api-gateway-nginx`.
-    Follow the instructions in [Choose access options](../access)
+    Follow the instructions in [Choose access options](../access/)
     to get the Keptn endpoint for the access option you are using
     and, optionally, storing that endpoint in an environment variable.
 
@@ -31,7 +31,7 @@ Do the following from the shell:
    ```
 
 1. To authenticate the CLI against the Keptn cluster,
-   use the [keptn auth](../../reference/cli/commands/keptn_auth) command:
+   use the [keptn auth](../../reference/cli/commands/keptn_auth/) command:
 
    ```
    keptn auth --endpoint=$KEPTN_ENDPOINT --api-token=$KEPTN_API_TOKEN
@@ -75,7 +75,7 @@ Do the folllowing in the Windows Command Line:
    ```
 
 1. To authenticate the CLI against the Keptn cluster,
-   use the [keptn auth](../../reference/cli/commands/keptn_auth) command:
+   use the [keptn auth](../../reference/cli/commands/keptn_auth/) command:
 
    ```
    keptn.exe auth --endpoint=$Env:KEPTN_ENDPOINT --api-token=$Env:KEPTN_API_TOKEN

--- a/content/docs/1.0.x/install/authenticate-cli-bridge/index.md
+++ b/content/docs/1.0.x/install/authenticate-cli-bridge/index.md
@@ -4,7 +4,7 @@ description: Authenticate the Keptn CLI and Bridge to your Keptn cluster
 weight: 60
 ---
 
-After you [instal Keptn](../helm-install/),
+After you [install Keptn](../helm-install/),
 you must authenticate the Keptn CLI and Bridge against the Keptn cluster.
 To do this, you need to:
 

--- a/content/docs/1.0.x/install/authenticate-cli-bridge/index.md
+++ b/content/docs/1.0.x/install/authenticate-cli-bridge/index.md
@@ -90,7 +90,7 @@ You can also use the Keptn CLI to retrieve the Bridge URL using:
 keptn status
 ```
 
-The Keptn Bridge has [basic authentication](../../bridge/basic_authentication)
+The Keptn Bridge has [basic authentication](../../bridge/basic_authentication/)
 enabled by default and the default user is `keptn` with an automatically generated password.
 
 * To get the username for authentication, execute:
@@ -106,8 +106,8 @@ kubectl get secret -n keptn bridge-credentials -o jsonpath="{.data.BASIC_AUTH_PA
 ```
 
 * If you want to change the user and password for the authentication,
-follow the instructions [here](../../bridge/basic_authentication/#enable-authentication).
+follow the instructions [here](../../bridge/basic_authentication/#enable-authentication/).
 
-See [OpenID Authorization](../../bridge/oauth)
+See [OpenID Authorization](../../bridge/oauth/)
 for information about using OAUTH authorization for the Keptn Bridge.
 

--- a/content/docs/1.0.x/install/cli-install/index.md
+++ b/content/docs/1.0.x/install/cli-install/index.md
@@ -11,11 +11,11 @@ Install it on the local machine
 that is used to interact with your cloud provider, Kubernetes, etc.
 
 The Keptn CLI sends commands to Keptn by interacting with the Keptn API.
-The [API Token](../../operate/api_token)
+The [API Token](../../operate/api_token/)
 that is used to communicate with Keptn is generated during the installation.
 
 It is possible to run Keptn without installing the Keptn CLI.
-Current Keptn releases allow you to create a project or run a sequence using the [Keptn Bridge](../../bridge),
+Current Keptn releases allow you to create a project or run a sequence using the [Keptn Bridge](../../bridge/),
 and this may be adequate for demos or personal environments you set up for study..
 But the CLI is required for some functionality
 and it should be installed on production systems.
@@ -124,5 +124,5 @@ To install the Keptn CLI from the binaries:
 
 After you install both the Keptn CLI and Keptn itself,
 you must authenticate the CLI and the Bridge.
-See [Authenticate Keptn CLI and Bridge](../authenticate-cli-bridge).
+See [Authenticate Keptn CLI and Bridge](../authenticate-cli-bridge/).
 

--- a/content/docs/1.0.x/install/cli-install/index.md
+++ b/content/docs/1.0.x/install/cli-install/index.md
@@ -32,7 +32,7 @@ You can use the `curl` command to install the Keptn CLI on Linux, WSL2, and macO
 Windows users need `bash`, `curl`, and `awk` installed (e.g., using Git Bash).
 
 1. Download the *latest stable Keptn version*
-   from [GitHub](https://github.com/keptn/keptn/releases),
+   from [GitHub](https://github.com/keptn/keptn/releases/),
    unpack it, and install it into the current directory on your cloud shell machine:
 
    ```

--- a/content/docs/1.0.x/install/cli-install/index.md
+++ b/content/docs/1.0.x/install/cli-install/index.md
@@ -16,7 +16,7 @@ that is used to communicate with Keptn is generated during the installation.
 
 It is possible to run Keptn without installing the Keptn CLI.
 Current Keptn releases allow you to create a project or run a sequence using the [Keptn Bridge](../../bridge/),
-and this may be adequate for demos or personal environments you set up for study..
+and this may be adequate for demos or personal environments you set up for study.
 But the CLI is required for some functionality
 and it should be installed on production systems.
 
@@ -33,18 +33,14 @@ Windows users need `bash`, `curl`, and `awk` installed (e.g., using Git Bash).
 
 1. Download the *latest stable Keptn version*
    from [GitHub](https://github.com/keptn/keptn/releases/),
-   unpack it, and install it into the current directory on your cloud shell machine:
+   unpack it, and install on your machine,
+   usually to `/usr/local/bin`.:
 
    ```
    curl -sL https://get.keptn.sh/ | bash
    ```
 
    Use **sudo** to move the file to another location.
-   such as `/usr/local/bin/keptn`.
-   You can run the Keptn CLI from any directory
-   but you may need to specify the location of the executable
-   or add the directory to your $PATH definition.,
-   Remember to use  `./keptn` rather than just `keptn` if it is in your current directory.
 
 2. Verify that the installation has worked and that the version is correct.
    On Linux and macOS, run:
@@ -52,12 +48,13 @@ Windows users need `bash`, `curl`, and `awk` installed (e.g., using Git Bash).
     ```
     keptn version
     ```
+
     On Windows, run:
 
     ```
     .\keptn.exe version
     ```
-## Install on macOS using brew
+## Install on macOS using Homebrew
 
 1. Run the following command to automatically fetch the latest Keptn CLI via Homebrew:
 
@@ -123,6 +120,6 @@ To install the Keptn CLI from the binaries:
       ```
 
 After you install both the Keptn CLI and Keptn itself,
-you must authenticate the CLI and the Bridge.
+you must authenticate the CLI.
 See [Authenticate Keptn CLI and Bridge](../authenticate-cli-bridge/).
 

--- a/content/docs/1.0.x/install/cli-install/index.md
+++ b/content/docs/1.0.x/install/cli-install/index.md
@@ -4,19 +4,21 @@ description: Install binaries for the Keptn CLI
 weight: 35
 ---
 
-Install the Keptn CLI on the local machine
-that is used to interact with your cloud provider, Kubernetes, etc.
 The Keptn CLI is not Keptn itself
 but is instead an interface to Keptn,
 much as **kubectl** is an interface to Kubernetes.
+Install it on the local machine
+that is used to interact with your cloud provider, Kubernetes, etc.
 
 The Keptn CLI sends commands to Keptn by interacting with the Keptn API.
-The [API Token](../../operate/api_token/)
+The [API Token](../../operate/api_token)
 that is used to communicate with Keptn is generated during the installation.
 
-It is not absolutely necessary to install the Keptn CLI for current Keptn releases,
-which allow you to create a project or run a sequence using the [Keptn Bridge](../../bridge/),
-but it is recommended for production systems.
+It is possible to run Keptn without installing the Keptn CLI.
+Current Keptn releases allow you to create a project or run a sequence using the [Keptn Bridge](../../bridge),
+and this may be adequate for demos or personal environments you set up for study..
+But the CLI is required for some functionality
+and it should be installed on production systems.
 
 You can install the Keptn CLI using:
 
@@ -24,48 +26,103 @@ You can install the Keptn CLI using:
 * Homebrew (MacOS only)
 * Standard binary installation tools for your operating system
 
-## curl
+## Install with curl
 
-```
-curl -sL https://get.keptn.sh/ | bash
-```
+You can use the `curl` command to install the Keptn CLI on Linux, WSL2, and macOS.
+Windows users need `bash`, `curl`, and `awk` installed (e.g., using Git Bash).
 
-This installs the Keptn CLI for you in the current directory on your cloud shell machine.
-You can use **sudo** to move the file to another location.
-You can run the Keptn CLI from any directory
-but you may need to specify the location of the path,
-using `.keptn` rather than just `keptn` if it is in your current directory.
+1. Download the *latest stable Keptn version*
+   from [GitHub](https://github.com/keptn/keptn/releases),
+   unpack it, and install it into the current directory on your cloud shell machine:
 
-## Homebrew
+   ```
+   curl -sL https://get.keptn.sh/ | bash
+   ```
 
-```
-brew install keptn
-```
+   Use **sudo** to move the file to another location.
+   such as `/usr/local/bin/keptn`.
+   You can run the Keptn CLI from any directory
+   but you may need to specify the location of the executable
+   or add the directory to your $PATH definition.,
+   Remember to use  `./keptn` rather than just `keptn` if it is in your current directory.
 
-## Binaries
+2. Verify that the installation has worked and that the version is correct.
+   On Linux and macOS, run:
 
-Binaries for the Keptn CLI are provided for Linux, macOS, and Windows.
-
-- Download the latest version for your operating system from: [GitHub](https://github.com/keptn/keptn/releases)
-- Unpack the archive
-- Find the `keptn` binary in the unpacked directory
-
-  - *Linux / macOS*: Add executable permissions (``chmod +x keptn``), and move it to the desired destination (e.g. `mv keptn /usr/local/bin/keptn`)
-
-  - *Windows*: Copy the executable to the desired folder and add the executable to your PATH environment variable.
-
-- Now, verify that the installation has worked and that the version is correct by running:
-    - *Linux / macOS*
-
-    ```console
+    ```
     keptn version
     ```
+    On Windows, run:
 
-    - *Windows*
-
-    ```console
+    ```
     .\keptn.exe version
     ```
+## Install on macOS using brew
 
-**Note:** For the rest of the documentation we will stick to the *Linux / macOS* version of the commands.
+1. Run the following command to automatically fetch the latest Keptn CLI via Homebrew:
+
+   ```
+   brew install keptn
+   ```
+
+1. Verify that the installation has worked and that the version is correct by running:
+
+   ```
+   keptn version
+   ```
+
+1. To upgrade Keptn CLI to a new release, run:
+
+   ```
+   brew upgrade keptn
+   ```
+
+1. To uninstall Keptn CLI, run:
+
+   ```
+   brew uninstall keptn
+   ```
+
+## Install Keptn CLI from binaries
+
+Each release of Keptn provides binaries for the Keptn CLI.
+These binaries are available for Linux, macOS, and Windows.
+To install the Keptn CLI from the binaries:
+
+1. Download the
+   [version matching your operating system](https://github.com/keptn/keptn/releases/).
+1. Unpack the archive.
+1. Find the `keptn` binary in the unpacked directory.
+   * For *Linux / macOS*:
+     * Add executable permissions:
+       ```
+       chmod +x keptn
+       ```
+     * Move the `keptn` binary to the desired destination
+       For example,
+       ```
+       mv keptn /usr/local/bin/keptn
+       ```
+
+   * For *Windows*:
+     * Move/copy the executable to the desired folder.
+     * Optionally, add the executable to the `PATH` environment variable.
+
+1. Verify that the installation has worked and that the version is correct.
+
+   * On Linux or MacOS, run:
+
+     ```
+     keptn version
+     ```
+
+    * On Windows, run:
+
+      ```
+      .\keptn.exe version
+      ```
+
+After you install both the Keptn CLI and Keptn itself,
+you must authenticate the CLI and the Bridge.
+See [Authenticate Keptn CLI and Bridge](../authenticate-cli-bridge).
 

--- a/content/docs/1.0.x/reference/cli/_index.md
+++ b/content/docs/1.0.x/reference/cli/_index.md
@@ -1,197 +1,41 @@
 ---
 title: Keptn CLI
-description: Explains how to download and install the Keptn CLI as well as which commands are available.
+description: Usage information and full syntax of CLI commands.
 weight: 30
 icon: help
 ---
 
-In this section, the functionality and commands of the Keptn CLI are described. The Keptn CLI allows installing, configuring, and uninstalling Keptn. Furthermore, the CLI allows creating projects, services, and sending new artifact events.
+This section provides detailed usage information for the Keptn CLI commands.
+The Keptn CLI includes commands to perform various tasks
+to manage the Keptn installaton and the projects that are run.
+It is packaged separately from the Keptn product itself.
+It is possible to run current versions of Keptn without the Keptn CLI;
+most basic functionality can instead be performed
+using the [Keptn bridge](../../bridge/).
+However, it is recommended that the CLI be installed for production environments
+because some functionality is available only through the CLI.
 
-## Automatic install of Keptn CLI
-
-**Note**: This will work on Linux (and WSL2), as well as macOS. Windows users need `bash`, `curl`, and `awk` installed (e.g., using Git Bash).
-
-1. Download the *latest stable Keptn version* from [GitHub](https://github.com/keptn/keptn/releases), unpack it and move it to `/usr/local/bin/keptn`.
-```console
-curl -sL https://get.keptn.sh | bash
-```
-
-2. Verify that the installation has worked and that the version is correct by running:
-    ```console
-    keptn version
-    ```
-    or if you are on Windows
-    ```console
-    .\keptn.exe version
-    ```
-
-## Installation on macOS using brew
-
-The following command will automatically fetch the latest Keptn CLI via Homebrew
-
-```sh
-brew install keptn
-```
-
-Verify that the installation has worked and that the version is correct by running:
-```console
-keptn version
-```
-
-### Updating
-
-```sh
-brew upgrade keptn
-```
-
-### Uninstall
-
-```sh
-brew uninstall keptn
-```
-
-## Download and manual install of Keptn CLI
-Every release of Keptn provides binaries for the Keptn CLI. These binaries are available for Linux, macOS, and Windows.
-
-1. Download the [version matching your operating system](https://github.com/keptn/keptn/releases/)
-1. Unpack the download
-1. Find the `keptn` binary in the unpacked directory.
-  - *Linux / macOS*: Add executable permissions (``chmod +x keptn``), and move it to the desired destination (e.g. `mv keptn /usr/local/bin/keptn`)
-
-  - *Windows*: move/copy the executable to the desired folder and, optionally, add the executable to the PATH environment variable for a more convenient experience.
-
-1. Verify that the installation has worked and that the version is correct by running:
-```console
-keptn version
-```
+See [Install Keptn CLI](../../install/cli-install/) for full installation instructions.
+After you install both the Keptn CLI and Keptn itself,
+you must authenticate the CLI and the Bridge
+as discussed in
+[Authenticate Keptn CLI and Bridge](../../install/authenticate-cli-bridge/).
 
 ## Start using Keptn CLI
 
-In the following, the commands provided by the Keptn CLI are described. To list all available commands just execute:
+These reference pages describe all the commands provided by the Keptn CLI.
+To list all available commands just execute:
     
-```console
+```
 keptn --help
 ```
 
-All of these commands also support the help flag (`--help`), which describes details of the respective command (e.g., usage of the command or description of flags).
+Each Keptn CLI command also supports the help flag (`--help`),
+which describes details of the respective command,
+including usage tips for the command and description of flags and arguments.
 
-## Authenticate Keptn CLI
-
-To authenticate the Keptn CLI against the Keptn cluster, the exposed Keptn endpoint and API token are required. 
-
-* Get the Keptn endpoint from the `api-gateway-nginx`. (If you are using port-forward to expose Keptn, your endpoint is `localhost` and the `port` you forwarded Keptn to, e.g.: `http://localhost:8080`) 
-
-  ```console
-kubectl -n keptn get service api-gateway-nginx
-  ```
-
-  ```console
-NAME                TYPE        CLUSTER-IP    EXTERNAL-IP                  PORT(S)   AGE
-api-gateway-nginx   ClusterIP   10.117.0.20   <ENDPOINT_OF_API_GATEWAY>    80/TCP    44m
-  ```
-
-<details><summary>Retrieve API Token and Authenticate Keptn CLI on **Linux / macOS**</summary>
-<p>
-
-* Set the environment variable `KEPTN_ENDPOINT`:
-
-```console
-KEPTN_ENDPOINT=<ENDPOINT_OF_API_GATEWAY>
-```
-
-* Set the environment variable `KEPTN_API_TOKEN`:
-
-```console
-KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)
-```
-
-* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../reference/cli/commands/keptn_auth/) command:
-
-```console
-keptn auth --endpoint=$KEPTN_ENDPOINT --api-token=$KEPTN_API_TOKEN
-```
-
-**Note**: If you receive a warning `Using a file-based storage for the key because the password-store seems to be not set up.` this is because a password store could not be found in your environment. In this case, the credentials are stored in `~/.keptn/.password-store` in your home directory.
-</p>
-</details>
-
-<details><summary>Retrieve API Token and Authenticate Keptn CLI on **Windows**</summary>
-<p>
-
-Please expand the corresponding section matching your CLI tool:
-
-<details><summary>PowerShell</summary>
-<p>
-
-For the Windows PowerShell, a small script is provided that installs the `PSYaml` module and sets the environment variables.
-
-* Set the environment variable `KEPTN_ENDPOINT`:
-
-```console
-$Env:KEPTN_ENDPOINT = '<ENDPOINT_OF_API_GATEWAY>'
-```
-
-* Copy the following snippet and paste it in the PowerShell. The snippet retrieves the API token and sets the environment variable `KEPTN_API_TOKEN`:
-
-```
-$tokenEncoded = $(kubectl get secret keptn-api-token -n keptn -ojsonpath='{.data.keptn-api-token}')
-$Env:KEPTN_API_TOKEN = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($tokenEncoded))
-```
-
-* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../reference/cli/commands/keptn_auth/) command:
-
-```
-keptn auth --endpoint=$Env:KEPTN_ENDPOINT --api-token=$Env:KEPTN_API_TOKEN
-```
-
-</p>
-</details>
-
-<details><summary>Command Line</summary>
-<p>
-
-In the Windows Command Line, a couple of steps are necessary.
-
-* Set the environment variable `KEPTN_ENDPOINT`:
-
-```console
-set KEPTN_ENDPOINT=<ENDPOINT_OF_API_GATEWAY>
-```
-
-* Get the Keptn API Token encoded in base64:
-
-```console
-kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token}
-```
-
-```console
-abcdefghijkladfaea
-```
-
-* Take the encoded API token - it is the value from the key `keptn-api-token` (in this example, it is `abcdefghijkladfaea`) and save it in a text file, e.g., `keptn-api-token-base64.txt`
-
-* Decode the file:
-
-```
-certutil -decode keptn-api-token-base64.txt keptn-api-token.txt
-```
-
-* Open the newly created file `keptn-api-token.txt`, copy the value and paste it into the next command:
-
-```
-set KEPTN_API_TOKEN=keptn-api-token
-```
-
-* To authenticate the CLI against the Keptn cluster, use the [keptn auth](../../reference/cli/commands/keptn_auth/) command:
-
-```
-keptn.exe auth --endpoint=%KEPTN_ENDPOINT% --api-token=%KEPTN_API_TOKEN%
-```
-
-</p>
-</details>
-</p>
-</details>
+The rest of this introduction provides some usage notes
+to make the Keptn CLI more convenient.
 
 ## Use Keptn CLI with multiple contexts
 
@@ -250,7 +94,7 @@ source /usr/share/bash-completion/bash_completion
 
 Reload your shell and verify that bash-completion is correctly installed by typing `type _init_completion`.
 
-### Enable Keptn CLI autocompletion for linux (bash)
+### Enable Keptn CLI autocompletion for Linux (bash)
 
 You now need to ensure that the Keptn CLI completion script gets sourced in all your shell sessions. There are two ways in which you can do this:
 


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

This PR does the following:
* Remove install/authenticate instructions from the CLI reference section
* Merges appropriate information into the install/cli-install page
* Merges appropriate information into the install/autheticate-cli-bridge page
* Also adds links to the Bridge pages about basic authentication and oauth

This PR replaces https://github.com/keptn/keptn.github.io/pull/1562/ , which in turn replaced https://github.com/keptn/keptn.github.io/pull/1542 .