### PR TITLE
Sitemap clean up

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,8 @@ title = "keptn | Cloud-native application life-cycle orchestration"
 theme = "hugo-serif-theme"
 relativeUrls = false
 enableEmoji = true
+enableGitInfo = true
+
 
 ignoreFiles = [
 "^(.*/docs/0.7.x/*)$",

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,0 +1,15 @@
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{{ $versionUsed := print "docs/" $.Site.Params.version}}
+{{ range .Data.Pages -}}
+    {{ if not .Params.private -}}
+        {{ if or (in .Permalink $versionUsed) (not (in .Permalink "docs"))}}
+    <url>
+        <loc>{{ .Permalink }}</loc>
+        <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ with .Sitemap.ChangeFreq }}
+        <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+        <priority>{{ .Sitemap.Priority }}</priority>{{ end }}
+    </url>
+	    {{- end }}
+	{{- end }}
+  {{- end }}
+</urlset>


### PR DESCRIPTION
Our sitemap contained too many pages, also those which are refering to a more up to date version. This is/was problematic for SEO. Search engines do see the sitemap as source of truth and get confused if there are pages, which declare themselves as outdated. Hence that, we are removing all outdated versions from the sitemap.xml

Signed-off-by: Simon Schrottner <simon.schrottner@dynatrace.com>