### PR TITLE
Adding a more robust logic to canonical urls

### DIFF
--- a/layouts/partials/canonical.html
+++ b/layouts/partials/canonical.html
@@ -1,7 +1,15 @@
-
-  {{ if in .Permalink "docs/0."}}
-    {{ $versionUsed := print "docs/" $.Site.Params.version}}
-    {{ $canoncical := replaceRE "docs/0.[[:digit:]]{1,2}.([[:digit:]]{1.2}|x)" $versionUsed .Permalink }}
+{{ $versionUsed := print "docs/" $.Site.Params.version -}}
+{{ if in .Permalink "docs/0." -}}
+  {{ $canoncical := replaceRE "docs/0.[[:digit:]]{1,2}.([[:digit:]]{1.2}|x)" $versionUsed .Permalink -}}
+  {{ if .GetPage $canoncical -}}
     <link rel="canonical" href="{{ $canoncical | absURL}}"/>
-
-{{end}}
+  {{ else }}
+    {{ range .Site.Pages -}}
+      {{ if in .Aliases $canoncical -}}
+        <link rel="canonical" href="{{ .Permalink | absURL}}"/>
+      {{- end }}
+    {{- end}}
+  {{- end}}
+{{ else if in .Permalink $versionUsed -}}
+  <link rel="canonical" href="{{ .Permalink | absURL}}"/>
+{{- end}}


### PR DESCRIPTION
Checking first if a page exists, if not, we are checking for aliases and use the proper page with the aliases.

Additionally we add some self referential links to the page.

Signed-off-by: Simon Schrottner <simon.schrottner@dynatrace.com>

This fixes our 333 issues with canonical URLs, which are just redirecting and therefore are suboptimal :)

![image](https://user-images.githubusercontent.com/9987394/213139304-7793104d-4a80-4fcf-901a-6a00e0176857.png)
