### PR TITLE
Update to 1.1.0; parameterize release number

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,9 @@ We were all new to this once and are happy to help you!
 We use standard markdown syntax to author the documentation.
 See the [Markdown Guide](https://www.markdownguide.org/) for information.
 
-Note that we have implemented Site Engine Optimization (SEO) for the Keptn documentation.
+## Syntax of cross-references
+
+We have implemented Site Engine Optimization (SEO) for the Keptn documentation.
 This has some ramifications:
 
 * Cross-references to a page (usually a source file itself) must use a trailing slash.
@@ -37,6 +39,16 @@ This has some ramifications:
 
 The CI tools check this syntax for each PR and PR's that do not conform to this practice
 do not pass CI tests and so cannot be merged.
+
+### Specifying release number
+
+Beginning with Release 1.1.0, the release number is parameterized.
+Use the `{{< param "version" >}}` string in command lines and elsewhere
+that the current version is specified.
+This renders to the value of the `version=` field in the `config.yaml` file.
+When updating the documentation for a new release,
+modify the `config.yaml` file and all occurences of the parameterized release number
+are updated automatically.
 
 ## Guidelines for contributing
 

--- a/config.toml
+++ b/config.toml
@@ -23,7 +23,7 @@ ignoreFiles = [
 
 [params]
     google_analytics_id="UA-133584243-1"
-    version="1.0.x"
+    version="1.1.0"
 
 [params.carouselHomepage]
     enable = true

--- a/content/docs/1.0.x/api/git_provisioning/index.md
+++ b/content/docs/1.0.x/api/git_provisioning/index.md
@@ -14,7 +14,7 @@ When a project is created, Keptn performs a call to the service that adheres to 
 Keptn calls the service that implements such interface passing the project name and the namespace in which Keptn is currently running. The service is expected to answer with the URL, username, and token to access the repository. Keptn uses this information to configure the upstream repository for the project.
 Similarly, when a project is deleted, Keptn calls the service implementing such an API. This can be used to deprovision the repository and perform clean up actions.
 
-This feature is enabled via the Helm value [`features.automaticProvisioning.serviceURL`](https://github.com/keptn/keptn/blob/1.0.0/installer/manifests/keptn/values.yaml#L47). This value must contain the base URL of the service that implements the interface.
+This feature is enabled via the Helm value [`features.automaticProvisioning.serviceURL`](https://github.com/keptn/keptn/blob/{{< param "version" >}}/installer/manifests/keptn/values.yaml#L47). This value must contain the base URL of the service that implements the interface.
 
 ---
 

--- a/content/docs/1.0.x/install/helm-install/index.md
+++ b/content/docs/1.0.x/install/helm-install/index.md
@@ -90,7 +90,7 @@ to port `8080` on the Keptn API Gateway service in the cluster.
   that are appropriate for installing a fully-functional production Keptn instance.
   They use the following options:
 
-  * `--version 1.0.0` -- Keptn release to be installed.
+  * `--version {{< param "version" >}}` -- Keptn release to be installed.
      If you do not specify the release, Helm uses the latest release.
 
    * `--repo=https://charts.keptn.sh` -- the location of the Helm chart.
@@ -107,7 +107,7 @@ to port `8080` on the Keptn API Gateway service in the cluster.
 
   ```
   helm upgrade keptn keptn --install -n keptn --create-namespace --wait \
-    --version=1.0.0 --repo=https://charts.keptn.sh \
+    --version={{< param "version" >}} --repo=https://charts.keptn.sh \
     --set=apiGatewayNginx.type=LoadBalancer
   ```
 
@@ -207,12 +207,12 @@ See the `README`file for a description of the parameters.
 * The **Control Plane with the Execution Plane (for Continuous Delivery)**
 can be installed by the following command:
 ```
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=1.0.0 --repo=https://charts.keptn.sh --set=continuousDelivery.enabled=true
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version={{< param "version" >}} --repo=https://charts.keptn.sh --set=continuousDelivery.enabled=true
 ```
 
 * The **Control Plane with the Execution Plane (for Continuous Delivery)** and a `LoadBalancer` for exposing Keptn can be installed by the following command:
 ```
-helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=1.0.0 --repo=https://charts.keptn.sh --set=continuousDelivery.enabled=true,apiGatewayNginx.type=LoadBalancer
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version={{< param "version" >}} --repo=https://charts.keptn.sh --set=continuousDelivery.enabled=true,apiGatewayNginx.type=LoadBalancer
 ```
 
 ## Install Keptn using a user-provided API token
@@ -241,7 +241,7 @@ The following artifacts must be available locally:
 
 Download the Helm charts from the GitHub release pages:
 
-* Keptn Control Plane: https://github.com/keptn/keptn/releases/download/1.0.0/keptn-1.0.0.tgz
+* Keptn Control Plane: https://github.com/keptn/keptn/releases/download/{{< param "version" >}}/keptn-{{< param "version" >}}.tgz
 * helm-service (if needed): https://github.com/keptn-contrib/helm-service/releases/download/0.18.1/helm-service-0.18.1.tgz
 * jmeter-service (if needed): https://github.com/keptn-contrib/jmeter-service/releases/download/0.18.1/jmeter-service-0.18.1.tgz
 
@@ -252,7 +252,7 @@ For convenience, the following script creates this directory and downloads the r
 ```
 mkdir offline-keptn
 cd offline-keptn
-curl -L https://github.com/keptn/keptn/releases/download/1.0.0/keptn-1.0.0.tgz -o keptn-1.0.0.tgz
+curl -L https://github.com/keptn/keptn/releases/download/{{< param "version" >}}/keptn-{{< param "version" >}}.tgz -o keptn-{{< param "version" >}}.tgz
 curl -L https://github.com/keptn-contrib/helm-service/releases/download/0.18.1/helm-service-0.18.1.tgz -o helm-service-0.18.1.tgz
 curl -L https://github.com/keptn-contrib/jmeter-service/releases/download/0.18.1/jmeter-service-0.18.1.tgz -o jmeter-service-0.18.1.tgz
 cd ..
@@ -269,9 +269,9 @@ For convenience, you can use the following commands to download and execute the 
 
 ```
 cd offline-keptn
-curl -L https://raw.githubusercontent.com/keptn/keptn/1.0.0/installer/airgapped/pull_and_retag_images.sh -o pull_and_retag_images.sh
+curl -L https://raw.githubusercontent.com/keptn/keptn/{{< param "version" >}}/installer/airgapped/pull_and_retag_images.sh -o pull_and_retag_images.sh
 chmod +x pull_and_retag_images.sh
-KEPTN_TAG=1.0.0 ./pull_and_retag_images.sh "your-registry.localhost:5000/"
+KEPTN_TAG={{< param "version" >}} ./pull_and_retag_images.sh "your-registry.localhost:5000/"
 cd ..
 ```
 
@@ -287,9 +287,9 @@ For convenience, you can use the following commands to download and execute the 
 
 ```
 cd offline-keptn
-curl -L https://raw.githubusercontent.com/keptn/keptn/1.0.0/installer/airgapped/install_keptn.sh -o install_keptn.sh
+curl -L https://raw.githubusercontent.com/keptn/keptn/{{< param "version" >}}/installer/airgapped/install_keptn.sh -o install_keptn.sh
 chmod +x install_keptn.sh
-./install_keptn.sh "your-registry.localhost:5000/" keptn-1.0.0.tgz \
+./install_keptn.sh "your-registry.localhost:5000/" keptn-{{< param "version" >}}.tgz \
    helm-service-0.18.1.tgz jmeter-service-0.18.1.tgz
 cd ..
 ```
@@ -304,7 +304,7 @@ the Keptn API is located under `http://HOSTNAME/mykeptn/api` and the Keptn Bridg
 
 ```
 helm upgrade keptn keptn --install -n keptn --create-namespace --wait \
-   --version=1.0.0 --repo=https://charts.keptn.sh \
+   --version={{< param "version" >}} --repo=https://charts.keptn.sh \
    --set=apiGatewayNginx.type=LoadBalancer,continuousDelivery.enabled=true,prefixPath=/mykeptn
 ```
 

--- a/content/docs/1.0.x/install/k8s/index.md
+++ b/content/docs/1.0.x/install/k8s/index.md
@@ -164,7 +164,7 @@ Please refer to the [official homepage of K3s](https://k3s.io) for detailed inst
 Please refer to the [official homepage of K3d](https://k3d.io/v5.3.0/) for detailed installation instructions. Here, a short guide on how to run Keptn on K3d is provided for a Linux environment.
 
 **Note:** [Docker](https://docs.docker.com/get-docker/) is required to use k3d.
-k3d v5.x.x requires at least Docker v20.10.5 (runc >= v1.0.0-rc93) to work properly.
+k3d v5.x.x requires at least Docker v20.10.5 (runc >= v{{< param "version" >}}-rc93) to work properly.
 
 You must install [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) before installing K3d. This is used to interact with the Kubernetes cluster.
 

--- a/content/docs/1.0.x/install/upgrade/index.md
+++ b/content/docs/1.0.x/install/upgrade/index.md
@@ -44,7 +44,7 @@ To upgrade the control plane:
 
 1. Download the released Helm chart using the following command
    replacing `<release>` with the release number to which you are upgrading,
-   such as `1.0.0`:
+   such as `{{< param "version" >}}`:
 
    ```
    helm pull https://charts.keptn.sh/packages/keptn-<release>.tgz
@@ -125,7 +125,7 @@ pages for more information.
 
 ## Upgrade notes by release
 
-### Upgrade from Keptn 0.19.x to Keptn 1.0.0-LTS
+### Upgrade from Keptn 0.19.x to Keptn {{< param "version" >}}-LTS
 
 No special steps are required to upgrade from Keptn 0.19.x to Keptn 1.0.x-LTS.
 

--- a/content/docs/1.0.x/integrations/custom_integration/index.md
+++ b/content/docs/1.0.x/integrations/custom_integration/index.md
@@ -54,7 +54,7 @@ The `PUBSUB_TOPIC` variable sets the initial subscription for your service. If a
 spec:
   containers:
   - name: distributor
-    image: keptn/distributor:1.0.0
+    image: keptn/distributor:{{< param "version" >}}
     ports:
     - containerPort: 8080
     resources:
@@ -271,7 +271,7 @@ spec:
     spec:
       containers:
       - name: distributor
-        image: keptn/distributor:1.0.0
+        image: keptn/distributor:{{< param "version" >}}
         ports:
         - containerPort: 8080
         resources:

--- a/content/docs/1.0.x/manage/service/index.md
+++ b/content/docs/1.0.x/manage/service/index.md
@@ -59,7 +59,7 @@ For Keptn, the [Helm Chart](https://Helm.sh/) has the following requirements:
 1. The Helm chart _must_ contain a `values.yaml` file with at least the `image` and `replicaCount` parameter for the deployment. These `image` and `replicaCount` parameters must be used in the deployment. An example is shown below:
 
   ```
-  image: docker.io/keptnexamples/carts:1.0.0
+  image: docker.io/keptnexamples/carts:{{< param "version" >}}
   replicaCount: 1
   ```
 

--- a/content/docs/1.0.x/manage/tasks/index.md
+++ b/content/docs/1.0.x/manage/tasks/index.md
@@ -156,7 +156,7 @@ The response will be a JSON object in the following format:
          "inputProperties":{
             "configurationChange":{
                "values":{
-                  "image":"docker.io/keptnexamples/some-service:1.0.0"
+                  "image":"docker.io/keptnexamples/some-service:{{< param "version" >}}"
                }
             },
             "deployment":{


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

ONLY GIOVANNI SHOULD MERGE THIS PR!

This PR does the following:
* Update the version= field in the config.yaml file to 1.1.0
* Parameterize the release number in places where the current release. string should always be parameterized
* Updated the CONTRIBUTING.md file to explain how release version is now parameterized

This PR does NOT do the following because I think these things are not required:
* Parameterize the release number when specified to the `keyword` field in the metadata
* Modify the contents of the "Upgrade" section for 1.1.0.  The title is "Upgrade from Keptn 0.19.x to 1.0.x" and I do not think we have any breaking changes that require user action in this release.  Let me know if I'm wrong and I will write up the new information.