### PR TITLE
Folder and Version difference hotfix

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -23,7 +23,10 @@ ignoreFiles = [
 
 [params]
     google_analytics_id="UA-133584243-1"
+    # our current version
     version="1.1.0"
+    # but our current version is in a different directory
+    versionDirectory="1.0.x"
 
 [params.carouselHomepage]
     enable = true

--- a/content/404/_index.md
+++ b/content/404/_index.md
@@ -1,3 +1,4 @@
 ---
 title: Page Not Found
+private: true
 ---

--- a/layouts/partials/canonical.html
+++ b/layouts/partials/canonical.html
@@ -1,7 +1,8 @@
-{{ $versionUsed := print "docs/" $.Site.Params.version -}}
-{{ if in .RelPermalink "docs/0." -}}
+{{ $versionUsed := print "docs/" $.Site.Params.versionDirectory -}}
+{{ if and (in .RelPermalink "docs") (not (in .RelPermalink $versionUsed)) -}}
   {{ $canoncical := replaceRE "docs/0.[[:digit:]]{1,2}.([[:digit:]]{1.2}|x)" $versionUsed .RelPermalink -}}
-  {{ if .GetPage $canoncical -}}
+  {{ $canoncicalPath := substr $canoncical 0 -1 -}}
+  {{ if .GetPage $canoncicalPath -}}
     <link rel="canonical" href="{{ $canoncical | absURL}}"/>
   {{ else }}
     {{ range .Site.Pages -}}

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,5 +1,5 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-{{ $versionUsed := print "docs/" $.Site.Params.version}}
+{{ $versionUsed := print "docs/" $.Site.Params.versionDirectory}}
 {{ range .Data.Pages -}}
     {{ if not .Params.private -}}
         {{ if or (in .RelPermalink $versionUsed) (not (in .RelPermalink "docs/"))}}


### PR DESCRIPTION
Currently we do have version 1.1.x but our folders are still 1.0.x - we use the same variable for version within the docs and for our SEO improvements. By raising the version, and not renaming also the directory all our canonical urls broke, and even our sitemap was not fully populated. To mitigate this, I introduced another variable, called `versionDirectory` which states, where our documentation is currently sitting and adapted all the necessary snippets.

Signed-off-by: Simon Schrottner <simon.schrottner@dynatrace.com>