### PR TITLE
Show 1.y.z requirements

### DIFF
--- a/content/docs/1.0.x/install/k8s-support/index.md
+++ b/content/docs/1.0.x/install/k8s-support/index.md
@@ -20,16 +20,16 @@ Keptn versions are expressed as `x.y.z`, where `x` is the major version, `y` is 
 
 | Keptn Version /<br>Installation                           | Kubernetes  | AKS                       | EKS                       | GKE           | OpenShift   | K3s         | Minishift               |
 |-----------------------------------------------------------|:-----------:|:-------------------------:|:-------------------------:|:-------------:|:-----------:|:-----------:|:------------------------|
-| **0.17.x** / <br>Control & Execution plane<br>*see: (1)*   | 1.22 - 1.17 | 1.22 - 1.19 | 1.22 - 1.19 | 1.22 - 1.19   | 4, 3.11     | 1.22 - 1.19 | 1.34.2<br>(K8s: 1.11)   |
-| **0.17.x** / <br>Control plane                             | 1.22 - 1.17 | 1.22 - 1.19 | 1.22 - 1.19 | 1.22 - 1.19   | 4, 3.11     | 1.22 - 1.19 | 1.34.2<br>(K8s: 1.11)   |
+| **0.18.x**, **0.19.x**, **1.y.z** / <br>Control & Execution plane<br> (*See: (1))*   | 1.24 - 1.17 | 1.24 - 1.19 | 1.24 - 1.19 | 1.24 - 1.19   | 4, 3.11     | 1.24 - 1.19 | 1.34.2<br>(K8s: 1.11)   |
+| **0.18.x**, **0.19.x**, **1.y.z** / <br>Control plane                             | 1.24 - 1.17 | 1.24 - 1.19 | 1.24 - 1.19 | 1.24 - 1.19   | 4, 3.11     | 1.24 - 1.19 | 1.34.2<br>(K8s: 1.11)   |
 
 **Remarks:**
 
-* (1): Requires sufficient resources (e.g., >= 8 vCPUs and 14 GB memory for deploying sockshop in multiple stages) depending on your use-case and workloads.
+* (1): Requires sufficient resources (number of vCPUs, amount of memory, and amount of disk space) to deploy your projects. The number and type of your projects, the number of stages in each, your use-case and workloads determine how many resources are required.
 
 **Notes:**
 
-* It is not recommended to use Keptn with a version of Kubernetes that is newer than the version it was tested against, as Keptn does not make any forward-compatibility guarantees.
+* It is not recommended to use Keptn with a version of Kubernetes that is newer than the version against which it was tested, as Keptn does not make any forward-compatibility guarantees.
 * If you choose to use Keptn with a version of Kubernetes that it does not support, you are using it at your own risk.
 * Installing Keptn on lightweight Kubernetes platforms such as KIND, Minikube, Microk8s, etc... *might* work (we recommend using *K3s*), but is not tested nor guaranteed. Please refer to the column called *Kubernetes* for the basic supported Kubernetes version.
 
@@ -45,14 +45,23 @@ Keptn versions are expressed as `x.y.z`, where `x` is the major version, `y` is 
 
 * With a new Keptn release, Keptn is tested based on the default Kubernetes version of each Cloud Provider: AKS, EKS and GKE available at the release date.
 
-* Internally, a test pipeline with newer Kubernetes versions is verifying the master branch of Keptn. Known-limitations identified by these tests are referenced at the corresponding Keptn release.
+* Internally, a test pipeline with newer Kubernetes versions is verifying the master branch of Keptn. Known-limitations identified by these tests are referenced in the corresponding Keptn [Release Announcements](../../../news/release_announcements/).
 
 ## Cluster size
 
 The size of the Keptn control plane has been derived automatically and is also reported at the latest release; see *Kubernetes Resource Data* at: [https://github.com/keptn/keptn/releases](https://github.com/keptn/keptn/releases).
 
-The predefined resource values for the Keptn services are available in the [Helm Charts](https://github.com/keptn/keptn/blob/0.17.0/installer/manifests/keptn/charts/control-plane/templates/core.yaml).
+The predefined resource values for the Keptn services are available in the [Helm Charts](https://github.com/keptn/keptn/blob/{{< param "version" >}}/installer/manifests/keptn/charts/control-plane/templates/core.yaml).
 
-As a rule of thumb, Keptn control plane will run with 2 vCPUs, 4 GB of memory and roughly 10 GB of additional disk space (Docker Images + Persistent Volumes).
+As a rule of thumb, Keptn control plane runs with 2 vCPUs, 4 GB of memory and roughly 10 GB of additional disk space (Docker Images + Persistent Volumes).  The amount of disk space required is mostly affected by the MongoDB usage.
 For execution plane services with continuous-delivery support, your Kubernetes cluster requires additional resources.
 This depends on the number of projects and workloads you deploy, as well as the number of stages in your Shipyard, and whether you are using direct or blue-green deployments.
+
+In particular, as you grow the number of projects and their size, it is recommended to increase:
+
+* The CPU limits of *shipyard-controller* and *resource-service*, and
+* The RAM limits of *resource-service*.
+
+As an example, we ran a stress test of a Keptn installation with 50 projects, each project having 5 stages and 50 services. Every second we ran an evaluation sequence, for a total of 5000 sequences.
+During the execution, we observed that the *shipyard-controller* required 1 full CPU and roughly 180MB of RAM. Similarly, the *resource-service* required around 3 CPUs and 240MB of RAM. 
+

--- a/content/docs/install/k8s-support/index.md
+++ b/content/docs/install/k8s-support/index.md
@@ -23,16 +23,16 @@ Keptn versions are expressed as `x.y.z`, where `x` is the major version, `y` is 
 
 | Keptn Version /<br>Installation                           | Kubernetes  | AKS                       | EKS                       | GKE           | OpenShift   | K3s         | Minishift               |
 |-----------------------------------------------------------|:-----------:|:-------------------------:|:-------------------------:|:-------------:|:-----------:|:-----------:|:------------------------|
-| **0.18.x**, **0.19.x** / <br>Control & Execution plane<br>*see: (1)*   | 1.24 - 1.17 | 1.24 - 1.19 | 1.24 - 1.19 | 1.24 - 1.19   | 4, 3.11     | 1.24 - 1.19 | 1.34.2<br>(K8s: 1.11)   |
-| **0.18.x**, **0.19.x** / <br>Control plane                             | 1.24 - 1.17 | 1.24 - 1.19 | 1.24 - 1.19 | 1.24 - 1.19   | 4, 3.11     | 1.24 - 1.19 | 1.34.2<br>(K8s: 1.11)   |
+| **0.18.x**, **0.19.x**, **1.y.z** / <br>Control & Execution plane<br> (*See: (1))*   | 1.24 - 1.17 | 1.24 - 1.19 | 1.24 - 1.19 | 1.24 - 1.19   | 4, 3.11     | 1.24 - 1.19 | 1.34.2<br>(K8s: 1.11)   |
+| **0.18.x**, **0.19.x**, **1.y.z** / <br>Control plane                             | 1.24 - 1.17 | 1.24 - 1.19 | 1.24 - 1.19 | 1.24 - 1.19   | 4, 3.11     | 1.24 - 1.19 | 1.34.2<br>(K8s: 1.11)   |
 
 **Remarks:**
 
-* (1): Requires sufficient resources (e.g., >= 8 vCPUs and 14 GB memory for deploying sockshop in multiple stages) depending on your use-case and workloads.
+* (1): Requires sufficient resources (number of vCPUs, amount of memory, and amount of disk space) to deploy your projects. The number and type of your projects, the number of stages in each, your use-case and workloads determine how many resources are required.
 
 **Notes:**
 
-* It is not recommended to use Keptn with a version of Kubernetes that is newer than the version it was tested against, as Keptn does not make any forward-compatibility guarantees.
+* It is not recommended to use Keptn with a version of Kubernetes that is newer than the version against which it was tested, as Keptn does not make any forward-compatibility guarantees.
 * If you choose to use Keptn with a version of Kubernetes that it does not support, you are using it at your own risk.
 * Installing Keptn on lightweight Kubernetes platforms such as KIND, Minikube, Microk8s, etc... *might* work (we recommend using *K3s*), but is not tested nor guaranteed. Please refer to the column called *Kubernetes* for the basic supported Kubernetes version.
 
@@ -48,15 +48,15 @@ Keptn versions are expressed as `x.y.z`, where `x` is the major version, `y` is 
 
 * With a new Keptn release, Keptn is tested based on the default Kubernetes version of each Cloud Provider: AKS, EKS and GKE available at the release date.
 
-* Internally, a test pipeline with newer Kubernetes versions is verifying the master branch of Keptn. Known-limitations identified by these tests are referenced at the corresponding Keptn release.
+* Internally, a test pipeline with newer Kubernetes versions is verifying the master branch of Keptn. Known-limitations identified by these tests are referenced in the corresponding Keptn [Release Announcements](../../news/release_announcements/).
 
 ## Cluster size
 
 The size of the Keptn control plane has been derived automatically and is also reported at the latest release; see *Kubernetes Resource Data* at: [https://github.com/keptn/keptn/releases](https://github.com/keptn/keptn/releases).
 
-The predefined resource values for the Keptn services are available in the [Helm Charts](https://github.com/keptn/keptn/blob/0.17.0/installer/manifests/keptn/charts/control-plane/templates/core.yaml).
+The predefined resource values for the Keptn services are available in the [Helm Charts](https://github.com/keptn/keptn/blob/{{< param "version" >}}/installer/manifests/keptn/charts/control-plane/templates/core.yaml).
 
-As a rule of thumb, Keptn control plane will run with 2 vCPUs, 4 GB of memory and roughly 10 GB of additional disk space (Docker Images + Persistent Volumes).
+As a rule of thumb, Keptn control plane runs with 2 vCPUs, 4 GB of memory and roughly 10 GB of additional disk space (Docker Images + Persistent Volumes).  The amount of disk space required is mostly affected by the MongoDB usage.
 For execution plane services with continuous-delivery support, your Kubernetes cluster requires additional resources.
 This depends on the number of projects and workloads you deploy, as well as the number of stages in your Shipyard, and whether you are using direct or blue-green deployments.
 


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

Somehow this page never got updated for 1.y.z.  The requirements are the same as for 0.18.x and 0.19.x.  Just to make things easier, I put the same content in the version at the root of the docs landing page as well as in the 1.0.x/install version.  The only difference is the path for the link to the Release Announcements.

Also tweaked some prose and hinted at MongoDB's impact on disk space requirements.  No time to research specifics but at least we give.a hint.