### PR TITLE
Point to Tracetest from define section

### DIFF
--- a/content/docs/1.0.x/define/tracetest/index.md
+++ b/content/docs/1.0.x/define/tracetest/index.md
@@ -17,3 +17,6 @@ and includes detailed instructions for implementing it with Keptn
 * [Tracetest integration for Keptn](https://artifacthub.io/packages/keptn/keptn-integrations/tracetest)
 is the integration you can download
 
+* Official [Tracetest documentation](https://docs.tracetest.io/tools-and-integrations/keptn/)
+
+

--- a/content/docs/1.0.x/define/tracetest/index.md
+++ b/content/docs/1.0.x/define/tracetest/index.md
@@ -1,0 +1,19 @@
+---
+title: Implement Tracetest trace-based testing with Keptn
+description: Use Tracetest to build integration and end-to-end tests powered by your OpenTelemetry traces
+weight: 245
+---
+
+[Tracetest](https://tracetest.io/) leverages your OpenTelemetry traces
+to enable trace-based testing with assertions against your trace data
+at every point of the request transaction.
+
+See:
+
+* [Announcing the Tracetest integration with Keptn](https://tracetest.io/blog/announcing-the-tracetest-integration-with-keptn-the-control-plane-for-cloud-native-application-life-cycle-orchestration)
+describes the Tracetest capabilities
+and includes detailed instructions for implementing it with Keptn
+
+* [Tracetest integration for Keptn](https://artifacthub.io/packages/keptn/keptn-integrations/tracetest)
+is the integration you can download
+


### PR DESCRIPTION
This PR provides a bit of information about using Tracetest with documentation.

Adnan's blog post and documentation on the Integrations page are excellent so I went for short and sweet?  Would it be better if I added a little bit more, like maybe the "we make it possible" list from the blog that gives more details about Tracetest or do we figure that anyone who is curious can click and get to all the information?

Do you have a video or anything else you would like linked?