### PR TITLE
new location for ADOPTERS file

### DIFF
--- a/content/resources/user-adoption/index.md
+++ b/content/resources/user-adoption/index.md
@@ -52,4 +52,4 @@ Please subscribe to our [Keptn YouTube channel](https://www.youtube.com/c/keptn/
 
 ## More adopters
 
-Find more Keptn adopters and get yourself listed [in our public adopters file](https://github.com/keptn/keptn/blob/master/ADOPTERS.md).
+Find more Keptn adopters and get yourself listed [in our public adopters file](https://github.com/keptn/community/blob/main/ADOPTERS).

--- a/layouts/partials/happy-users-logos.html
+++ b/layouts/partials/happy-users-logos.html
@@ -5,7 +5,7 @@
         <img class="js-happy-users-logo" data-proofer-ignore>
     </div>
     {{ end }}
-    <a href="https://github.com/keptn/keptn/blob/master/ADOPTERS.md">
+    <a href="https://github.com/keptn/community/blob/main/ADOPTERS">
         <img src="/images/home/add-organisation.svg">
     </a>
 </div>


### PR DESCRIPTION
This fixes the broken xref to the ADOPTERS file, which was recently moved to the community repo.  This links to the raw markdown file.  It would be better if it linked to a rendered file but this at least fixes the broken xref which is causing other PRs to fail CI.