### PR TITLE
Add information about running tasks in parallel

### DIFF
--- a/content/docs/1.0.x/define/parallel/index.md
+++ b/content/docs/1.0.x/define/parallel/index.md
@@ -1,0 +1,60 @@
+---
+title: Run tasks in parallel
+description: Strategies to run tasks in parallel
+weight: 170
+keywords: [1.0.x-manage]
+aliases:
+- /docs/1.0.x/manage/parallel/
+---
+
+Sequences that use the same service cannot be run in parallel.
+If you simultaneously trigger multiple sequences for the same service,
+they are queued to run sequentially.
+Sequences for different services can be run in parallel.
+This is possible when you have different automation projects
+or if you have multiple services within a project.
+
+You can run tasks in parallel by putting them in different stages,
+each of which is triggered from the previous stage.
+The following [shipyard](../../reference/files/shipyard) illustrates this.
+Here, you see we have three stages:
+
+* `hardening`
+* `load-test-1`
+* `load-test-2`
+
+Both `load-test-1` and `load-test-2` are triggered
+by the `hardening.delivery.finished` event
+so will run in parallel.
+
+```yaml
+apiVersion: "spec.keptn.sh/0.2.3"
+kind: "Shipyard"
+metadata:
+  name: "shipyard-example-parallel-tasks"
+spec:
+  stages:
+    - name: "hardening"
+      sequences:
+        - name: "delivery"
+          tasks:
+            - name: "deployment"
+              properties:
+                deploymentstrategy: "direct"
+            - name: "evaluation"
+            - name: "release"
+    - name: "load-test-1"
+      sequences:
+        - name: "load-test"
+          triggeredOn:
+            - event: "hardening.delivery.finished"
+          tasks:
+            - name: "my-load-test-configuration"
+    - name: "load-test-2"
+      sequences:
+        - name: "load-test"
+          triggeredOn:
+            - event: "hardening.delivery.finished"
+          tasks:
+            - name: "my-load-test-configuration"
+```

--- a/content/docs/1.0.x/define/parallel/index.md
+++ b/content/docs/1.0.x/define/parallel/index.md
@@ -16,7 +16,7 @@ or if you have multiple services within a project.
 
 You can run tasks in parallel by putting them in different stages,
 each of which is triggered from the previous stage.
-The following [shipyard](../../reference/files/shipyard) illustrates this.
+The following [shipyard](../../reference/files/shipyard/) illustrates this.
 Here, you see we have three stages:
 
 * `hardening`

--- a/content/docs/1.0.x/define/triggers/index.md
+++ b/content/docs/1.0.x/define/triggers/index.md
@@ -20,7 +20,7 @@ in the the [shipyard](../../reference/files/shipyard/)
 to specify an event that triggers this sequence,
 implicitly linking two sequences.
 
-Each of these mechanismsis discussed below.
+Each of these mechanisms is discussed below.
 
 ## Use triggeredOn in a sequence
 

--- a/content/docs/1.0.x/reference/files/shipyard/index.md
+++ b/content/docs/1.0.x/reference/files/shipyard/index.md
@@ -133,6 +133,12 @@ Sequences for different services can be run in parallel.
 This is possible when you have different automation projects
 or if you have multiple services within a project.
 
+If you need to run different tasks in parallel,
+a better strategy is to create separate stages,
+both of which are triggered from the previous stage.
+See [Run tasks in parallel](../../../define/parallel)
+for an example of how to do this.
+
 A sequence has the properties:
 
 * `name`: A unique name for the sequence
@@ -356,3 +362,4 @@ and  named to match the value of the `Metadata` name field in the shipyard file.
 * [Quality gates](../../../define/quality-gates/)
 * [Triggers](../../../define/triggers/)
 * [Remediation configuration](../remediation/)
+* [Run tasks in parallel](../../../define/parallel)

--- a/content/docs/1.0.x/reference/files/shipyard/index.md
+++ b/content/docs/1.0.x/reference/files/shipyard/index.md
@@ -362,4 +362,4 @@ and  named to match the value of the `Metadata` name field in the shipyard file.
 * [Quality gates](../../../define/quality-gates/)
 * [Triggers](../../../define/triggers/)
 * [Remediation configuration](../remediation/)
-* [Run tasks in parallel](../../../define/parallel)
+* [Run tasks in parallel](../../../define/parallel/)

--- a/content/docs/1.0.x/reference/files/shipyard/index.md
+++ b/content/docs/1.0.x/reference/files/shipyard/index.md
@@ -136,7 +136,7 @@ or if you have multiple services within a project.
 If you need to run different tasks in parallel,
 a better strategy is to create separate stages,
 both of which are triggered from the previous stage.
-See [Run tasks in parallel](../../../define/parallel)
+See [Run tasks in parallel](../../../define/parallel/)
 for an example of how to do this.
 
 A sequence has the properties:


### PR DESCRIPTION
* Create "Run tasks in parallel" page in the "Define Keptn Project" section to preserve Giovanni's information about creating multiple stages that trigger off a previous stage.
* Link to this new page from the shipyard reference file that discusses parallelism
* Fixed a tiny typo in the define/triggers page because I saw it and it wasn't worth a separate PR.

Thanks to Francesco Furnari for asking the question and @thisthat for providing the answer!