### PR TITLE
remove the colliding of buttton in the integration docs 

### DIFF
--- a/assets/scss/pages/_doc.scss
+++ b/assets/scss/pages/_doc.scss
@@ -659,3 +659,9 @@ figcaption {
   color: white;
   font-family: $font-family-base;
 }
+input, button, select, optgroup, textarea {
+  margin: 3px;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}


### PR DESCRIPTION
Signed-off-by: Nitishupkr [nitishupkr@gmail.com](mailto:nitishupkr@gmail.com)
fixes : #1640 
the text buttons which are colliding are now fixed they are not colliding and its is responsive to the all device .And a Netlify build is ready to be used so we can display the page and check the docs section of the integration
see:https://friendly-longma-79936e.netlify.app/docs/integrations/